### PR TITLE
exposing additional types and fixing dashboard folder method names

### DIFF
--- a/go/dashboard-folders-client.go
+++ b/go/dashboard-folders-client.go
@@ -34,6 +34,9 @@ type CreateDashboardFolderRequest = dashboards.CreateDashboardFolderRequest
 // DashboardFolder is a dashboard folder.
 type DashboardFolder = dashboards.DashboardFolder
 
+// ListDashboardFolderRequest is a request to get a dashboard folders.
+type GetDashboardFolderRequest = dashboards.GetDashboardFolderRequest
+
 // Create creates a new dashboard folder.
 func (c DashboardsFoldersClient) Create(ctx context.Context, req *dashboards.CreateDashboardFolderRequest) (*dashboards.CreateDashboardFolderResponse, error) {
 	callProperties, err := c.callPropertiesCreator.GetCallProperties(ctx)
@@ -48,8 +51,22 @@ func (c DashboardsFoldersClient) Create(ctx context.Context, req *dashboards.Cre
 	return client.CreateDashboardFolder(callProperties.Ctx, req, callProperties.CallOptions...)
 }
 
-// Get gets all dashboard folders.
-func (c DashboardsFoldersClient) Get(ctx context.Context, req *dashboards.ListDashboardFoldersRequest) (*dashboards.ListDashboardFoldersResponse, error) {
+// Get dashboard folder details.
+func (c DashboardsFoldersClient) Get(ctx context.Context, req *dashboards.GetDashboardFolderRequest) (*dashboards.GetDashboardFolderResponse, error) {
+	callProperties, err := c.callPropertiesCreator.GetCallProperties(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := callProperties.Connection
+	defer conn.Close()
+	client := dashboards.NewDashboardFoldersServiceClient(conn)
+
+	return client.GetDashboardFolder(callProperties.Ctx, req, callProperties.CallOptions...)
+}
+
+// List gets all dashboard folders.
+func (c DashboardsFoldersClient) List(ctx context.Context, req *dashboards.ListDashboardFoldersRequest) (*dashboards.ListDashboardFoldersResponse, error) {
 	callProperties, err := c.callPropertiesCreator.GetCallProperties(ctx)
 	if err != nil {
 		return nil, err

--- a/go/dashboard-folders-client.go
+++ b/go/dashboard-folders-client.go
@@ -34,7 +34,7 @@ type CreateDashboardFolderRequest = dashboards.CreateDashboardFolderRequest
 // DashboardFolder is a dashboard folder.
 type DashboardFolder = dashboards.DashboardFolder
 
-// ListDashboardFolderRequest is a request to get a dashboard folders.
+// GetDashboardFolderRequest is a request to get a dashboard folders.
 type GetDashboardFolderRequest = dashboards.GetDashboardFolderRequest
 
 // Create creates a new dashboard folder.

--- a/go/dashboard-folders-client.go
+++ b/go/dashboard-folders-client.go
@@ -66,7 +66,7 @@ func (c DashboardsFoldersClient) Get(ctx context.Context, req *dashboards.GetDas
 }
 
 // List gets all dashboard folders.
-func (c DashboardsFoldersClient) List(ctx context.Context, req *dashboards.ListDashboardFoldersRequest) (*dashboards.ListDashboardFoldersResponse, error) {
+func (c DashboardsFoldersClient) List(ctx context.Context) (*dashboards.ListDashboardFoldersResponse, error) {
 	callProperties, err := c.callPropertiesCreator.GetCallProperties(ctx)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (c DashboardsFoldersClient) List(ctx context.Context, req *dashboards.ListD
 	defer conn.Close()
 	client := dashboards.NewDashboardFoldersServiceClient(conn)
 
-	return client.ListDashboardFolders(callProperties.Ctx, req, callProperties.CallOptions...)
+	return client.ListDashboardFolders(callProperties.Ctx, &dashboards.ListDashboardFoldersRequest{}, callProperties.CallOptions...)
 }
 
 // Replace updates a dashboard folder.

--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -44,7 +44,7 @@ type PinDashboardRequest = dashboards.PinDashboardRequest
 type UnpinDashboardRequest = dashboards.UnpinDashboardRequest
 
 // Dashboard_FolderPath is a dashboard folder path.
-type Dashboard_FolderPath = dashboards.Dashboard_FolderPath
+type DashboardFolderPath = dashboards.Dashboard_FolderPath
 
 // FolderPath is a dashboard folder path.
 type FolderPath = dashboards.FolderPath

--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -43,7 +43,7 @@ type PinDashboardRequest = dashboards.PinDashboardRequest
 // UnpinDashboardRequest is a request to unpin a dashboard.
 type UnpinDashboardRequest = dashboards.UnpinDashboardRequest
 
-// Dashboard_FolderPath is a dashboard folder path.
+// DashboardFolderPath is a dashboard folder path.
 type DashboardFolderPath = dashboards.Dashboard_FolderPath
 
 // FolderPath is a dashboard folder path.

--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -43,6 +43,12 @@ type PinDashboardRequest = dashboards.PinDashboardRequest
 // UnpinDashboardRequest is a request to unpin a dashboard.
 type UnpinDashboardRequest = dashboards.UnpinDashboardRequest
 
+// Dashboard_FolderPath is a dashboard folder path.
+type Dashboard_FolderPath = dashboards.Dashboard_FolderPath
+
+// FolderPath is a dashboard folder path.
+type FolderPath = dashboards.FolderPath
+
 // Dashboard is a dashboard.
 type Dashboard = dashboards.Dashboard
 


### PR DESCRIPTION
1. Exposing additional types
2. BREAKING: `DashboardsFoldersClient` method `Get()` was fetching a list of folders and there was no method to get folder details, even though API supports it. I've renamed `Get()` -> `List()` (smilaraliliy to `Dashboards` method `List()`) and added dedicated `Get()` method.