### PR TITLE
Fix domain issue

### DIFF
--- a/go/cxsdk.go
+++ b/go/cxsdk.go
@@ -287,13 +287,12 @@ func CoralogixGrpcEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return GrpcAP3
 	default:
-		return regionIdentifier
+		return fmt.Sprintf("ng-api-grpc.%s:443", regionIdentifier)
 	}
 }
 
 // CoralogixRestEndpointFromRegion reads the Coralogix REST endpoint from environment variables.
 func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
-
 	switch regionIdentifier {
 	case "us1":
 		return RestUS1
@@ -310,7 +309,7 @@ func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return RestAP3
 	default:
-		return regionIdentifier
+		return fmt.Sprintf("https://ng-api-http.%s", regionIdentifier)
 	}
 }
 

--- a/rust/cx-sdk/src/lib.rs
+++ b/rust/cx-sdk/src/lib.rs
@@ -84,7 +84,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-grpc.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-grpc.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-grpc.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => format!("https://{}", custom),
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-grpc.{}:443", custom),
         }
     }
 
@@ -99,9 +99,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-http.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-http.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-http.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => {
-                format!("https://{}", custom.replace("grpc", "http"))
-            }
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-http.{}", custom),
         }
     }
 


### PR DESCRIPTION
Before this PR, the SDK client set wasn't useable with custom domains, because it expected a single full URL. 
The issue is that gRPC and rest endpoints are using different URLs ([More info](https://github.com/coralogix/coralogix-management-sdk/blob/c9f281620cbb61fe52e21df174adb13c8028432b/go/cxsdk.go#L28-L48)), so the SDK should receive the custom domain (and not full URL), and then build its gRPC/rest clients accordingly. 
