### PR TITLE
Replace URL with domain name in SDK configuration

### DIFF
--- a/go/cxsdk.go
+++ b/go/cxsdk.go
@@ -287,13 +287,12 @@ func CoralogixGrpcEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return GrpcAP3
 	default:
-		return regionIdentifier
+		return fmt.Sprintf("ng-api-grpc.%s:443", regionIdentifier)
 	}
 }
 
 // CoralogixRestEndpointFromRegion reads the Coralogix REST endpoint from environment variables.
 func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
-
 	switch regionIdentifier {
 	case "us1":
 		return RestUS1
@@ -310,7 +309,7 @@ func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return RestAP3
 	default:
-		return regionIdentifier
+		return fmt.Sprintf("https://ng-api-http.%s", regionIdentifier)
 	}
 }
 

--- a/rust/cx-sdk/src/lib.rs
+++ b/rust/cx-sdk/src/lib.rs
@@ -84,7 +84,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-grpc.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-grpc.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-grpc.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => format!("https://{}", custom),
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-grpc.{}:443", custom),
         }
     }
 
@@ -99,9 +99,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-http.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-http.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-http.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => {
-                format!("https://{}", custom.replace("grpc", "http"))
-            }
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-http.{}", custom),
         }
     }
 


### PR DESCRIPTION
Since we have both gRPC and REST clients, we wanna accept only the domain name and then build the endpoint internally based on the services we need to interact with.