### PR TITLE
Fix incremental rust build

### DIFF
--- a/rust/cx-api/build.rs
+++ b/rust/cx-api/build.rs
@@ -18,8 +18,8 @@ const PROTOS_DIR: &str = "proto";
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../Cargo.lock");
-    println!("cargo:rerun-if-changed=protofetch.toml");
-    println!("cargo:rerun-if-changed=protofetch.lock");
+    println!("cargo:rerun-if-changed=../../protofetch.toml");
+    println!("cargo:rerun-if-changed=../../protofetch.lock");
 
     let mut project_root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
     project_root.pop();

--- a/rust/cx-api/build.rs
+++ b/rust/cx-api/build.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     project_root.push(PROTOS_DIR);
 
     let root = project_root.into_os_string().into_string().unwrap();
-    println!("root: {:?}", root);
+    println!("root: {root:?}");
     let building = &[
         #[cfg(feature = "alerts")]
         alerts_service(&root),
@@ -100,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(false)
         .build_client(true)
         .out_dir("src/generated")
-        .compile_protos(building, &[format!("{}/", root)])?;
+        .compile_protos(building, &[format!("{root}/")])?;
     Ok(())
 }
 

--- a/rust/cx-sdk/build.rs
+++ b/rust/cx-sdk/build.rs
@@ -28,21 +28,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn();
 
     if rustc_version_command.is_err() {
-        println!("cargo:rustc-env=RUSTC_VERSION={}", DEFAULT_VERSION_STRING);
+        println!("cargo:rustc-env=RUSTC_VERSION={DEFAULT_VERSION_STRING}");
         return Ok(());
     }
 
     let rustc_version_output = rustc_version_command.unwrap().wait_with_output();
 
     if rustc_version_output.is_err() {
-        println!("cargo:rustc-env=RUSTC_VERSION={}", DEFAULT_VERSION_STRING);
+        println!("cargo:rustc-env=RUSTC_VERSION={DEFAULT_VERSION_STRING}");
         return Ok(());
     }
 
     let rust_version_string = String::from_utf8(rustc_version_output.unwrap().stdout);
 
     if rust_version_string.is_err() {
-        println!("cargo:rustc-env=RUSTC_VERSION={}", DEFAULT_VERSION_STRING);
+        println!("cargo:rustc-env=RUSTC_VERSION={DEFAULT_VERSION_STRING}");
         return Ok(());
     }
 

--- a/rust/cx-sdk/src/lib.rs
+++ b/rust/cx-sdk/src/lib.rs
@@ -87,7 +87,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-grpc.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-grpc.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-grpc.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => format!("https://ng-api-grpc.{}:443", custom),
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-grpc.{custom}:443"),
         }
     }
 
@@ -102,7 +102,7 @@ impl CoralogixRegion {
             CoralogixRegion::AP1 => "https://ng-api-http.app.coralogix.in".into(),
             CoralogixRegion::AP2 => "https://ng-api-http.coralogixsg.com".into(),
             CoralogixRegion::AP3 => "https://ng-api-http.ap3.coralogix.com".into(),
-            CoralogixRegion::Custom(custom) => format!("https://ng-api-http.{}", custom),
+            CoralogixRegion::Custom(custom) => format!("https://ng-api-http.{custom}"),
         }
     }
 
@@ -144,7 +144,7 @@ impl From<&ApiKey> for metadata::CallProperties {
                 ),
                 (
                     HeaderName::from_static(SDK_VERSION_HEADER_NAME),
-                    HeaderValue::from_str(format!("sdk-{}", SDK_VERSION).as_str()).unwrap(),
+                    HeaderValue::from_str(format!("sdk-{SDK_VERSION}").as_str()).unwrap(),
                 ),
                 (
                     HeaderName::from_static(SDK_LANGUAGE_HEADER_NAME),


### PR DESCRIPTION
Fix `rerun-if-changed` file references to avoid re-running the build script when nothing has changed.

I'm actually not sure that you even want to mention these protofetch files in your build.rs, as you don't run protofetch as a part of your build script.