### PR TITLE
chore: updating 'cx-api-data-usage' protobufs

### DIFF
--- a/protofetch.lock
+++ b/protofetch.lock
@@ -51,8 +51,8 @@ commit_hash = "845f340d2928a531a1c78c8c1e8731846ff45c13"
 [[dependencies]]
 name = "cx-api-data-usage"
 url = "github.com/coralogix/cx-api-data-usage"
-revision = "v0.3.18"
-commit_hash = "dc2ced635a0a29f03c1f11efadeac023e20719dd"
+revision = "v0.3.19"
+commit_hash = "2ea51405c1b5fe05a94dabd3ea98b0b62135422e"
 
 [[dependencies]]
 name = "cx-api-enrichment"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -279,7 +279,7 @@ revision = "v0.3.4"
 
 [cx-api-data-usage]
 url = 'github.com/coralogix/cx-api-data-usage'
-revision = "v0.3.18"
+revision = "v0.3.19"
 allow_policies = [
     "src/com/coralogix/datausage/v1/common.proto",
     "src/com/coralogix/datausage/v2/data_usage.proto",
@@ -322,11 +322,7 @@ allow_policies = [
     "src/com/coralogixapis/scopes/v1/entity_type.proto",
     "src/com/coralogixapis/scopes/v1/scopes.proto",
 ]
-<<<<<<< HEAD
 revision = "v0.0.4"
-=======
-revision = 'v0.0.4'
->>>>>>> 507d13a0 (Migrate to openapiv3)
 
 [cx-api-apm]
 url = 'github.com/coralogix/cx-api-apm'


### PR DESCRIPTION
cx-api-data-usage: v0.3.17 -> v0.3.19
