### PR TITLE
whitelisted the new placement proto file in the Protofetcfh.toml file

### DIFF
--- a/protofetch.toml
+++ b/protofetch.toml
@@ -161,7 +161,7 @@ allow_policies = [
 
 [cx-api-quota]
 url = 'github.com/coralogix/cx-api-quota'
-revision = "v0.0.11"
+revision = "v0.0.12"
 allow_policies = [
     "src/com/coralogix/quota/v1/archive_retention.proto",
     "src/com/coralogix/quota/v1/atomic_overwrite_policies_request.proto",
@@ -194,6 +194,7 @@ allow_policies = [
     "src/com/coralogix/quota/v1/toggle_policy_response.proto",
     "src/com/coralogix/quota/v1/update_policy_request.proto",
     "src/com/coralogix/quota/v1/update_policy_response.proto",
+    "src/com/coralogix/quota/v1/placement.proto",
 ]
 
 [cx-api-dashboards]


### PR DESCRIPTION
as part of the [RDNT-2753](https://coralogix.atlassian.net/browse/RDNT-2753) task - I need to create a build for ws-quota-grpc and deploy it. I get an error in the build for the mismatch of the cx-quota-api proto version. also the new placement file was missing.

[RDNT-2753]: https://coralogix.atlassian.net/browse/RDNT-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ