### PR TITLE
chore: updating 'cx-api-incidents' protobufs

### DIFF
--- a/go/internal/coralogixapis/incidents/v1/incidents_service.pb.go
+++ b/go/internal/coralogixapis/incidents/v1/incidents_service.pb.go
@@ -2156,7 +2156,7 @@ const file_com_coralogixapis_incidents_v1_incidents_service_proto_rawDesc = "" +
 	"\x15Internal server errorj.\n" +
 	"\x16x-coralogixPermissions\x12\x142\x12\n" +
 	"\x10\x1a\x0eincidents:readʸ\x02\x14\n" +
-	"\x12Get incidents list\x82\xd3\xe4\x93\x02-:\x01*Z\x0f\"\r/v1/incidents\x12\x17/incidents/incidents/v1\x12\x9c\x04\n" +
+	"\x12Get incidents list\x82\xd3\xe4\x93\x02-:\x01*Z\x0f\"\r/v1/incidents\"\x17/incidents/incidents/v1\x12\x9c\x04\n" +
 	"\x18ListIncidentAggregations\x12?.com.coralogixapis.incidents.v1.ListIncidentAggregationsRequest\x1a@.com.coralogixapis.incidents.v1.ListIncidentAggregationsResponse\"\xfc\x02\x9aA\xff\x01\n" +
 	"\x11Incidents service\x12\x19Get incident aggregations\x1aJRetrieve aggregated incident data with support for grouping and filtering.J\x14\n" +
 	"\x03400\x12\r\n" +

--- a/proto/com/coralogixapis/incidents/v1/incidents_service.proto
+++ b/proto/com/coralogixapis/incidents/v1/incidents_service.proto
@@ -96,7 +96,7 @@ service IncidentsService {
   rpc ListIncidents(ListIncidentsRequest) returns (ListIncidentsResponse) {
     option (com.coralogixapis.common.v1.audit_log_description).description = "Get incidents list";
     option (google.api.http) = {
-      get: "/incidents/incidents/v1"
+      post: "/incidents/incidents/v1"
       body: "*"
       additional_bindings: {post: "/v1/incidents"}
     };

--- a/protofetch.lock
+++ b/protofetch.lock
@@ -75,8 +75,8 @@ commit_hash = "3155267a44c2d11c6b4e2db25c18e244cfc07b2f"
 [[dependencies]]
 name = "cx-api-incidents"
 url = "github.com/coralogix/cx-api-incidents"
-revision = "v1.0.7"
-commit_hash = "2c63c90025cc296b9e0e22ce5e41d7f22543a314"
+revision = "v1.0.8"
+commit_hash = "6761e7abd0be81d92e7cf26bbb58f0e2740436e4"
 
 [[dependencies]]
 name = "cx-api-lmd-model"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -443,7 +443,7 @@ allow_policies = [
 
 [cx-api-incidents]
 url = 'github.com/coralogix/cx-api-incidents'
-revision = "v1.0.7"
+revision = "v1.0.8"
 allow_policies = [
     "src/com/coralogixapis/incidents/v1/assignee.proto",
     "src/com/coralogixapis/incidents/v1/filter_operators.proto",


### PR DESCRIPTION
cx-api-incidents: v1.0.7 -> v1.0.8
