### PR TITLE
chore: updating 'cx-api-data-usage' protobufs

### DIFF
--- a/go/internal/coralogix/datausage/v1/common.pb.go
+++ b/go/internal/coralogix/datausage/v1/common.pb.go
@@ -203,6 +203,7 @@ const (
 	Range_RANGE_LAST_30_DAYS  Range = 2
 	Range_RANGE_LAST_90_DAYS  Range = 3
 	Range_RANGE_LAST_WEEK     Range = 4
+	Range_RANGE_LAST_YEAR     Range = 5
 )
 
 // Enum value maps for Range.
@@ -213,6 +214,7 @@ var (
 		2: "RANGE_LAST_30_DAYS",
 		3: "RANGE_LAST_90_DAYS",
 		4: "RANGE_LAST_WEEK",
+		5: "RANGE_LAST_YEAR",
 	}
 	Range_value = map[string]int32{
 		"RANGE_UNSPECIFIED":   0,
@@ -220,6 +222,7 @@ var (
 		"RANGE_LAST_30_DAYS":  2,
 		"RANGE_LAST_90_DAYS":  3,
 		"RANGE_LAST_WEEK":     4,
+		"RANGE_LAST_YEAR":     5,
 	}
 )
 
@@ -577,13 +580,14 @@ const file_com_coralogix_datausage_v1_common_proto_rawDesc = "" +
 	"\rSEVERITY_INFO\x10\x03\x12\x14\n" +
 	"\x10SEVERITY_WARNING\x10\x04\x12\x12\n" +
 	"\x0eSEVERITY_ERROR\x10\x05\x12\x15\n" +
-	"\x11SEVERITY_CRITICAL\x10\x06*|\n" +
+	"\x11SEVERITY_CRITICAL\x10\x06*\x91\x01\n" +
 	"\x05Range\x12\x15\n" +
 	"\x11RANGE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13RANGE_CURRENT_MONTH\x10\x01\x12\x16\n" +
 	"\x12RANGE_LAST_30_DAYS\x10\x02\x12\x16\n" +
 	"\x12RANGE_LAST_90_DAYS\x10\x03\x12\x13\n" +
-	"\x0fRANGE_LAST_WEEK\x10\x04*\xe4\x01\n" +
+	"\x0fRANGE_LAST_WEEK\x10\x04\x12\x13\n" +
+	"\x0fRANGE_LAST_YEAR\x10\x05*\xe4\x01\n" +
 	"\n" +
 	"Resolution\x12\x1a\n" +
 	"\x16RESOLUTION_UNSPECIFIED\x10\x00\x12\x19\n" +

--- a/go/internal/coralogix/datausage/v2/data_usage.pb.go
+++ b/go/internal/coralogix/datausage/v2/data_usage.pb.go
@@ -32,6 +32,7 @@ const (
 	Range_RANGE_LAST_30_DAYS  Range = 2
 	Range_RANGE_LAST_90_DAYS  Range = 3
 	Range_RANGE_LAST_WEEK     Range = 4
+	Range_RANGE_LAST_YEAR     Range = 5
 )
 
 // Enum value maps for Range.
@@ -42,6 +43,7 @@ var (
 		2: "RANGE_LAST_30_DAYS",
 		3: "RANGE_LAST_90_DAYS",
 		4: "RANGE_LAST_WEEK",
+		5: "RANGE_LAST_YEAR",
 	}
 	Range_value = map[string]int32{
 		"RANGE_UNSPECIFIED":   0,
@@ -49,6 +51,7 @@ var (
 		"RANGE_LAST_30_DAYS":  2,
 		"RANGE_LAST_90_DAYS":  3,
 		"RANGE_LAST_WEEK":     4,
+		"RANGE_LAST_YEAR":     5,
 	}
 )
 
@@ -1200,13 +1203,14 @@ const file_com_coralogix_datausage_v2_data_usage_proto_rawDesc = "" +
 	"\n" +
 	"Evaluation\x12C\n" +
 	"\x0eevaluator_name\x18\x01 \x01(\v2\x1c.google.protobuf.StringValueR\revaluatorName\x12N\n" +
-	"\x11evaluation_tokens\x18\x02 \x01(\v2!.com.coralogix.datausage.v2.TokenR\x10evaluationTokens*|\n" +
+	"\x11evaluation_tokens\x18\x02 \x01(\v2!.com.coralogix.datausage.v2.TokenR\x10evaluationTokens*\x91\x01\n" +
 	"\x05Range\x12\x15\n" +
 	"\x11RANGE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13RANGE_CURRENT_MONTH\x10\x01\x12\x16\n" +
 	"\x12RANGE_LAST_30_DAYS\x10\x02\x12\x16\n" +
 	"\x12RANGE_LAST_90_DAYS\x10\x03\x12\x13\n" +
-	"\x0fRANGE_LAST_WEEK\x10\x04*\x7f\n" +
+	"\x0fRANGE_LAST_WEEK\x10\x04\x12\x13\n" +
+	"\x0fRANGE_LAST_YEAR\x10\x05*\x7f\n" +
 	"\x06Pillar\x12\x16\n" +
 	"\x12PILLAR_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0ePILLAR_METRICS\x10\x01\x12\x0f\n" +

--- a/proto/com/coralogix/datausage/v1/common.proto
+++ b/proto/com/coralogix/datausage/v1/common.proto
@@ -58,6 +58,7 @@ enum Range {
   RANGE_LAST_30_DAYS = 2;
   RANGE_LAST_90_DAYS = 3;
   RANGE_LAST_WEEK = 4;
+  RANGE_LAST_YEAR = 5;
 }
 
 enum Resolution {

--- a/proto/com/coralogix/datausage/v2/data_usage.proto
+++ b/proto/com/coralogix/datausage/v2/data_usage.proto
@@ -45,6 +45,7 @@ enum Range {
   RANGE_LAST_30_DAYS = 2;
   RANGE_LAST_90_DAYS = 3;
   RANGE_LAST_WEEK = 4;
+  RANGE_LAST_YEAR = 5;
 }
 
 enum Pillar {

--- a/protofetch.lock
+++ b/protofetch.lock
@@ -45,8 +45,8 @@ commit_hash = "5818c8111e1e8d854d6dc2747e7e6dede6e5fb89"
 [[dependencies]]
 name = "cx-api-data-usage"
 url = "github.com/coralogix/cx-api-data-usage"
-revision = "v0.3.22"
-commit_hash = "3b5aa33ff2716ff51eeffc0b973a5b9307d8cbe3"
+revision = "v0.3.25"
+commit_hash = "9914cbb5b07d47fda8821785fe0020061a6be891"
 
 [[dependencies]]
 name = "cx-api-enrichment"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -282,7 +282,7 @@ revision = "v0.3.5"
 
 [cx-api-data-usage]
 url = 'github.com/coralogix/cx-api-data-usage'
-revision = "v0.3.22"
+revision = "v0.3.25"
 allow_policies = [
     "src/com/coralogix/datausage/v1/common.proto",
     "src/com/coralogix/datausage/v2/data_usage.proto",


### PR DESCRIPTION
cx-api-data-usage: v0.3.22 -> v0.3.25
