### PR TITLE
chore: updating 'cx-api-metrics-configurator' protobufs

### DIFF
--- a/protofetch.lock
+++ b/protofetch.lock
@@ -87,8 +87,8 @@ commit_hash = "5921c0e9bea453e15a75845dcfffc29cd5a1950b"
 [[dependencies]]
 name = "cx-api-metrics-configurator"
 url = "github.com/coralogix/cx-api-metrics-configurator"
-revision = "v0.0.9"
-commit_hash = "62ce096fa5eff10f78e1d3b6c8ea769d113147ee"
+revision = "v0.0.10"
+commit_hash = "2460edb255f5273584fd627612462f64aa45fef2"
 
 [[dependencies]]
 name = "cx-api-metrics-rule-manager"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -397,7 +397,7 @@ url = 'github.com/coralogix/cx-api-metrics-configurator'
 allow_policies = [
     "/src/com/coralogix/metrics/metrics-configurator.proto",
 ]
-revision = "v0.0.9"
+revision = "v0.0.10"
 
 [cx-api-metrics-rule-manager]
 url = "github.com/coralogix/cx-api-metrics-rule-manager"


### PR DESCRIPTION
cx-api-metrics-configurator: v0.0.9 -> v0.0.10
