### PR TITLE
chore: updating 'cx-api-data-usage' protobufs

### DIFF
--- a/protofetch.lock
+++ b/protofetch.lock
@@ -45,8 +45,8 @@ commit_hash = "0a8062e7ac2c7026076ad7c834c77541fea8dd2f"
 [[dependencies]]
 name = "cx-api-data-usage"
 url = "github.com/coralogix/cx-api-data-usage"
-revision = "v0.3.27"
-commit_hash = "102d617fd271f3812e5aff477fd621e1dac4554f"
+revision = "v0.3.29"
+commit_hash = "23fc213494c2acdf6fb31fc1addd083151eaf8d6"
 
 [[dependencies]]
 name = "cx-api-enrichment"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -284,7 +284,7 @@ revision = "v0.3.5"
 
 [cx-api-data-usage]
 url = 'github.com/coralogix/cx-api-data-usage'
-revision = "v0.3.27"
+revision = "v0.3.29"
 allow_policies = [
     "src/com/coralogix/datausage/v1/common.proto",
     "src/com/coralogix/datausage/v2/data_usage.proto",


### PR DESCRIPTION
cx-api-data-usage: v0.3.27 -> v0.3.29
