### PR TITLE
chore: updating 'cx-api-alerts' protobufs

### DIFF
--- a/protofetch.lock
+++ b/protofetch.lock
@@ -15,8 +15,8 @@ commit_hash = "11bae4e2cc0149c82f9271a33f2be44ddda34e61"
 [[dependencies]]
 name = "cx-api-alerts"
 url = "github.com/coralogix/cx-api-alerts"
-revision = "v0.5.37"
-commit_hash = "98f41412bde4bc9179e562db1c9b7956d113ddab"
+revision = "v0.5.38"
+commit_hash = "cd63cfff2f7697c29acf1c2e8404fd301dd5d243"
 
 [[dependencies]]
 name = "cx-api-apm"

--- a/protofetch.toml
+++ b/protofetch.toml
@@ -15,7 +15,7 @@ allow_policies = [
 
 [cx-api-alerts]
 url = 'github.com/coralogix/cx-api-alerts'
-revision = "v0.5.37"
+revision = "v0.5.38"
 allow_policies = [
     "src/com/coralogixapis/alerts/v3/alert_def.proto",
     "src/com/coralogixapis/alerts/v3/alert_def_notification_group.proto",


### PR DESCRIPTION
cx-api-alerts: v0.5.37 -> v0.5.38
