### PR TITLE
Add OpenAPI read-only list/get tests for many services

### DIFF
--- a/go/openapi/tests/actions_list_read_test.go
+++ b/go/openapi/tests/actions_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestActionsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewActionsClient(cfg)
+
+	listResp, httpResp, err := client.
+		ActionsServiceListActions(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Actions) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	actionID := listResp.Actions[0].GetId()
+	if actionID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ActionsServiceGetAction(context.Background(), actionID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, actionID, getResp.GetAction().GetId())
+}

--- a/go/openapi/tests/alerts_list_read_test.go
+++ b/go/openapi/tests/alerts_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestAlertsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewAlertsClient(cfg)
+
+	listResp, httpResp, err := client.
+		AlertDefsServiceListAlertDefs(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.AlertDefs) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	alertID := listResp.AlertDefs[0].GetId()
+	if alertID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		AlertDefsServiceGetAlertDef(context.Background(), alertID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, alertID, getResp.GetAlertDef().GetId())
+}

--- a/go/openapi/tests/api_keys_list_read_test.go
+++ b/go/openapi/tests/api_keys_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestAPIKeysListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewAPIKeysClient(cfg)
+
+	listResp, httpResp, err := client.
+		ApiKeysServiceGetSendDataApiKeys(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Keys) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	keyID := listResp.Keys[0].GetId()
+	if keyID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ApiKeysServiceGetApiKey(context.Background(), keyID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, keyID, getResp.GetKeyInfo().GetId())
+}

--- a/go/openapi/tests/archive_logs_list_read_test.go
+++ b/go/openapi/tests/archive_logs_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestArchiveLogsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewArchiveLogsClient(cfg)
+
+	listResp, httpResp, err := client.
+		S3TargetServiceGetTarget(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	listTarget := listResp.Target.GetActualInstance()
+	if listTarget == nil {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		S3TargetServiceGetTarget(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	getTarget := getResp.Target.GetActualInstance()
+	require.NotNil(t, getTarget)
+	require.Equal(t, reflect.TypeOf(listTarget), reflect.TypeOf(getTarget))
+}

--- a/go/openapi/tests/archive_metrics_list_read_test.go
+++ b/go/openapi/tests/archive_metrics_list_read_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestArchiveMetricsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewArchiveMetricsClient(cfg)
+
+	listResp, httpResp, err := client.
+		MetricsConfiguratorPublicServiceGetTenantConfig(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if listResp == nil || listResp.TenantConfig == nil {
+		t.Skip("no resources to read")
+	}
+
+	listConfig := listResp.TenantConfig.GetActualInstance()
+	if listConfig == nil {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		MetricsConfiguratorPublicServiceGetTenantConfig(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if getResp == nil || getResp.TenantConfig == nil {
+		t.Skip("no resources to read")
+	}
+
+	getConfig := getResp.TenantConfig.GetActualInstance()
+	require.NotNil(t, getConfig)
+	require.Equal(t, reflect.TypeOf(listConfig), reflect.TypeOf(getConfig))
+}

--- a/go/openapi/tests/archive_retentions_list_read_test.go
+++ b/go/openapi/tests/archive_retentions_list_read_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestArchiveRetentionsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewArchiveRetentionsClient(cfg)
+
+	listResp, httpResp, err := client.
+		RetentionsServiceGetRetentions(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Retentions) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	retentionID := listResp.Retentions[0].GetId()
+	if retentionID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		RetentionsServiceGetRetentions(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	found := false
+	for _, retention := range getResp.Retentions {
+		if retention.GetId() == retentionID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}

--- a/go/openapi/tests/connectors_list_read_test.go
+++ b/go/openapi/tests/connectors_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestConnectorsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewConnectorsClient(cfg)
+
+	listResp, httpResp, err := client.
+		ConnectorsServiceListConnectors(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Connectors) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	connectorID := listResp.Connectors[0].GetId()
+	if connectorID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ConnectorsServiceGetConnector(context.Background(), connectorID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, connectorID, getResp.GetConnector().GetId())
+}

--- a/go/openapi/tests/custom_enrichments_list_read_test.go
+++ b/go/openapi/tests/custom_enrichments_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestCustomEnrichmentsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewCustomEnrichmentsClient(cfg)
+
+	listResp, httpResp, err := client.
+		CustomEnrichmentServiceGetCustomEnrichments(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.CustomEnrichments) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	enrichmentID := listResp.CustomEnrichments[0].GetId()
+	if enrichmentID == 0 {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		CustomEnrichmentServiceGetCustomEnrichment(context.Background(), enrichmentID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, enrichmentID, getResp.GetCustomEnrichment().GetId())
+}

--- a/go/openapi/tests/custom_roles_list_read_test.go
+++ b/go/openapi/tests/custom_roles_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestCustomRolesListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewCustomRolesClient(cfg)
+
+	listResp, httpResp, err := client.
+		RoleManagementServiceListCustomRoles(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Roles) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	roleID := listResp.Roles[0].GetRoleId()
+	if roleID == 0 {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		RoleManagementServiceGetCustomRole(context.Background(), roleID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, roleID, getResp.GetRole().GetRoleId())
+}

--- a/go/openapi/tests/dashboard_folders_list_read_test.go
+++ b/go/openapi/tests/dashboard_folders_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestDashboardFoldersListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewDashboardFoldersClient(cfg)
+
+	listResp, httpResp, err := client.
+		DashboardFoldersServiceListDashboardFolders(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Folder) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	folderID := listResp.Folder[0].GetId()
+	if folderID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		DashboardFoldersServiceGetDashboardFolder(context.Background(), folderID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, folderID, getResp.GetFolder().GetId())
+}

--- a/go/openapi/tests/dashboards_list_read_test.go
+++ b/go/openapi/tests/dashboards_list_read_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestDashboardsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewDashboardClient(cfg)
+
+	listResp, httpResp, err := client.
+		DashboardCatalogServiceGetDashboardCatalog(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Items) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	dashboardID := listResp.Items[0].GetId()
+	if dashboardID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		DashboardsServiceGetDashboard(context.Background(), dashboardID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	actual := getResp.GetDashboard().GetActualInstance()
+	if actual == nil {
+		t.Skip("no resources to read")
+	}
+	idProvider, ok := actual.(interface{ GetId() string })
+	require.True(t, ok)
+	require.Equal(t, dashboardID, idProvider.GetId())
+}

--- a/go/openapi/tests/e2ms_list_read_test.go
+++ b/go/openapi/tests/e2ms_list_read_test.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestE2MsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewEvents2MetricsClient(cfg)
+
+	listResp, httpResp, err := client.
+		Events2MetricServiceListE2M(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.E2m) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	var e2mID string
+	if listResp.E2m[0].E2MLogsQuery != nil {
+		e2mID = listResp.E2m[0].E2MLogsQuery.GetId()
+	} else if listResp.E2m[0].E2MSpansQuery != nil {
+		e2mID = listResp.E2m[0].E2MSpansQuery.GetId()
+	}
+	if e2mID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		Events2MetricServiceGetE2M(context.Background(), e2mID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	var readID string
+	if getResp.E2m.E2MLogsQuery != nil {
+		readID = getResp.E2m.E2MLogsQuery.GetId()
+	} else if getResp.E2m.E2MSpansQuery != nil {
+		readID = getResp.E2m.E2MSpansQuery.GetId()
+	}
+	require.Equal(t, e2mID, readID)
+}

--- a/go/openapi/tests/enrichments_list_read_test.go
+++ b/go/openapi/tests/enrichments_list_read_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestEnrichmentsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewEnrichmentsClient(cfg)
+
+	listResp, httpResp, err := client.
+		EnrichmentServiceGetEnrichments(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Enrichments) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	enrichmentID := listResp.Enrichments[0].GetId()
+	if enrichmentID == 0 {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		EnrichmentServiceGetEnrichments(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	found := false
+	for _, enrichment := range getResp.Enrichments {
+		if enrichment.GetId() == enrichmentID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}

--- a/go/openapi/tests/extensions_list_read_test.go
+++ b/go/openapi/tests/extensions_list_read_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	extensions "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/extension_service"
+)
+
+func TestExtensionsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewExtensionsClient(cfg)
+
+	includeHidden := false
+	listReq := extensions.GetAllExtensionsRequest{
+		IncludeHiddenExtensions: &includeHidden,
+	}
+
+	listResp, httpResp, err := client.
+		ExtensionServiceGetAllExtensions(context.Background()).
+		GetAllExtensionsRequest(listReq).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Extensions) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	extensionID := listResp.Extensions[0].GetId()
+	if extensionID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ExtensionServiceGetExtension(context.Background(), extensionID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, extensionID, getResp.GetId())
+}

--- a/go/openapi/tests/groups_list_read_test.go
+++ b/go/openapi/tests/groups_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestGroupsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewGroupsClient(cfg)
+
+	listResp, httpResp, err := client.
+		TeamPermissionsMgmtServiceGetTeamGroups(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Groups) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	groupID := listResp.Groups[0].GetGroupId().GetId()
+	if groupID == 0 {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		TeamPermissionsMgmtServiceGetTeamGroup(context.Background(), groupID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, groupID, getResp.GetGroup().GetGroupId().GetId())
+}

--- a/go/openapi/tests/integrations_list_read_test.go
+++ b/go/openapi/tests/integrations_list_read_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	integrations "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/integration_service"
+)
+
+func integrationDetailsID(details integrations.IntegrationDetails) string {
+	actual := details.GetActualInstance()
+	switch typed := actual.(type) {
+	case *integrations.IntegrationDetailsExternal:
+		return typed.GetIntegration().GetId()
+	case *integrations.IntegrationDetailsLocal:
+		return typed.GetIntegration().GetId()
+	default:
+		return ""
+	}
+}
+
+func TestIntegrationsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewIntegrationsClient(cfg)
+
+	listResp, httpResp, err := client.
+		IntegrationServiceGetIntegrations(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Integrations) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	integrationID := listResp.Integrations[0].GetIntegration().GetId()
+	if integrationID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		IntegrationServiceGetIntegrationDetails(context.Background(), integrationID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, integrationID, integrationDetailsID(getResp.GetIntegrationDetail()))
+}

--- a/go/openapi/tests/ip_access_list_read_test.go
+++ b/go/openapi/tests/ip_access_list_read_test.go
@@ -1,0 +1,31 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestIPAccessListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewIPAccessClient(cfg)
+
+	listResp, httpResp, err := client.
+		IpAccessServiceGetCompanyIpAccessSettings(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	settingsID := listResp.GetSettings().GetId()
+	if settingsID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		IpAccessServiceGetCompanyIpAccessSettings(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, settingsID, getResp.GetSettings().GetId())
+}

--- a/go/openapi/tests/policies_list_read_test.go
+++ b/go/openapi/tests/policies_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestPoliciesListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewTCOPoliciesClient(cfg)
+
+	listResp, httpResp, err := client.
+		PoliciesServiceGetCompanyPolicies(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Policies) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	policyID := listResp.Policies[0].GetId()
+	if policyID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		PoliciesServiceGetPolicy(context.Background(), policyID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, policyID, getResp.GetPolicy().GetId())
+}

--- a/go/openapi/tests/presets_list_read_test.go
+++ b/go/openapi/tests/presets_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestPresetsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewPresetsClient(cfg)
+
+	listResp, httpResp, err := client.
+		PresetsServiceListPresetSummaries(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.PresetSummaries) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	presetID := listResp.PresetSummaries[0].GetId()
+	if presetID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		PresetsServiceGetPreset(context.Background(), presetID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, presetID, getResp.GetPreset().GetId())
+}

--- a/go/openapi/tests/recording_rules_list_read_test.go
+++ b/go/openapi/tests/recording_rules_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestRecordingRulesListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewRecordingRulesClient(cfg)
+
+	listResp, httpResp, err := client.
+		RuleGroupSetsList(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Sets) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	setID := listResp.Sets[0].GetId()
+	if setID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		RuleGroupSetsFetch(context.Background(), setID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, setID, getResp.GetId())
+}

--- a/go/openapi/tests/rule_groups_list_read_test.go
+++ b/go/openapi/tests/rule_groups_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestRuleGroupsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewRuleGroupsClient(cfg)
+
+	listResp, httpResp, err := client.
+		RuleGroupsServiceListRuleGroups(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.RuleGroups) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	groupID := listResp.RuleGroups[0].GetId()
+	if groupID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		RuleGroupsServiceGetRuleGroup(context.Background(), groupID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, groupID, getResp.GetRuleGroup().GetId())
+}

--- a/go/openapi/tests/scopes_list_read_test.go
+++ b/go/openapi/tests/scopes_list_read_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestScopesListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewScopesClient(cfg)
+
+	listResp, httpResp, err := client.
+		ScopesServiceGetTeamScopes(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Scopes) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	scopeID := listResp.Scopes[0].GetId()
+	if scopeID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ScopesServiceGetTeamScopesByIds(context.Background()).
+		Ids([]string{scopeID}).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	if len(getResp.Scopes) == 0 {
+		t.Skip("no resources to read")
+	}
+	require.Equal(t, scopeID, getResp.Scopes[0].GetId())
+}

--- a/go/openapi/tests/slos_list_read_test.go
+++ b/go/openapi/tests/slos_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestSLOsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewSLOsClient(cfg)
+
+	listResp, httpResp, err := client.
+		SlosServiceListSlos(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Slos) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	sloID := listResp.Slos[0].GetId()
+	if sloID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		SlosServiceGetSlo(context.Background(), sloID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, sloID, getResp.GetSlo().GetId())
+}

--- a/go/openapi/tests/views_folders_list_read_test.go
+++ b/go/openapi/tests/views_folders_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestViewsFoldersListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewViewsFoldersClient(cfg)
+
+	listResp, httpResp, err := client.
+		ViewsFoldersServiceListViewFolders(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Folders) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	folderID := listResp.Folders[0].GetId()
+	if folderID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ViewsFoldersServiceGetViewFolder(context.Background(), folderID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, folderID, getResp.GetFolder().GetId())
+}

--- a/go/openapi/tests/views_list_read_test.go
+++ b/go/openapi/tests/views_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestViewsListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewViewsClient(cfg)
+
+	listResp, httpResp, err := client.
+		ViewsServiceListViews(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Views) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	viewID := listResp.Views[0].GetId()
+	if viewID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		ViewsServiceGetView(context.Background(), viewID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, viewID, getResp.GetView().GetId())
+}

--- a/go/openapi/tests/webhooks_list_read_test.go
+++ b/go/openapi/tests/webhooks_list_read_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+)
+
+func TestWebhooksListRead(t *testing.T) {
+	cfg := cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()
+	client := cxsdk.NewWebhooksClient(cfg)
+
+	listResp, httpResp, err := client.
+		OutgoingWebhooksServiceListAllOutgoingWebhooks(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	if len(listResp.Deployed) == 0 {
+		t.Skip("no resources to read")
+	}
+
+	webhookID := listResp.Deployed[0].GetId()
+	if webhookID == "" {
+		t.Skip("no resources to read")
+	}
+
+	getResp, httpResp, err := client.
+		OutgoingWebhooksServiceGetOutgoingWebhook(context.Background(), webhookID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, webhookID, getResp.GetWebhook().GetId())
+}


### PR DESCRIPTION
### Motivation

- Provide non-destructive, stable coverage for many generated OpenAPI clients by testing list + read flows for existing resources.
- Mirror the config and error handling patterns used in `go/openapi/examples` by using `cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()` and `cxsdk.NewAPIError(httpResp, err)`.
- Ensure tests do not create, update, or delete resources so they can run safely against real tenants.
- Improve robustness when working with union/oneOf response models and differing response accessors.

### Description

- Added a new test package under `go/openapi/tests` and created 26 read-only tests that follow the list+read pattern for services such as `Actions`, `Alerts`, `Dashboards`, `DashboardFolders`, `Views`, `ViewsFolders`, `SLOs`, `RuleGroups`, `RecordingRules`, `Integrations`, `Connectors`, `Presets`, `APIKeys`, `IPAccess`, `Policies`, `Enrichments`, `CustomEnrichments`, `CustomRoles`, `Extensions`, and archive clients for logs/metrics/retentions. 
- Each test builds a `Config` with `cxsdk.NewConfigBuilder().WithAPIKeyEnv().WithRegionEnv().Build()`, calls the appropriate list endpoint, skips the test with `t.Skip("no resources to read")` if the list is empty, then calls the corresponding get/read endpoint and asserts identifiers match while using `require.NoError(t, cxsdk.NewAPIError(httpResp, err))` for API errors.
- Adjusted several tests to handle generated client/model differences, including using `GetKeyInfo()` for API Keys, `GetCustomEnrichment()` accessor for custom enrichments, reading `GetActualInstance()` for union/oneOf model types (e.g. dashboards, archive targets, integration details), and a small helper `integrationDetailsID` to extract the integration id from either external or local `IntegrationDetails`.
- Applied formatting via `gofmt` to the test files to ensure consistent Go formatting.

### Testing

- No automated test suite was executed as part of this change (`go test` was not run) so these are newly added test files only.
- The new test files are non-destructive and designed to be skipped when no resources exist, making them safe to run in CI environments that provide valid credentials and existing resources.
- `gofmt` was run to format the added Go files successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a0b4b35f88329a3aabf81a6f1e1eb)