### PR TITLE
Scope `IsNotFound` util to 404 returned from the backend

### DIFF
--- a/go/openapi/cxsdk/consts.go
+++ b/go/openapi/cxsdk/consts.go
@@ -26,4 +26,6 @@ const (
 	sdkGoVersionHeaderName     = "x-cx-go-version"
 	sdkCorrelationIDHeaderName = "x-cx-correlation-id"
 	vanillaSdkVersion          = "1.12.0"
+
+	notFoundPrefix = "Not Found:"
 )


### PR DESCRIPTION
Implementation is based on the facade's:
```go
case codes.NotFound:
  http.Error(w, "Not Found: "+status.Message(), http.StatusNotFound)
```