### PR TITLE
Refine Not Found util

### DIFF
--- a/go/openapi/cxsdk/consts.go
+++ b/go/openapi/cxsdk/consts.go
@@ -27,5 +27,6 @@ const (
 	sdkCorrelationIDHeaderName = "x-cx-correlation-id"
 	vanillaSdkVersion          = "1.12.0"
 
-	notFoundPrefix = "Not Found:"
+	notFoundPrefix        = "Not Found:"
+	notFoundGenericSuffix = "Not Found" // "Not Found: Not Found" = endpoint missing; "Not Found: <msg>" = resource not found
 )


### PR DESCRIPTION
Exclude `Not Found: Not Found` which returns for missing endpoint.