### PR TITLE
AtomicOverwriteCustomEnrichments new endpoint

### DIFF
--- a/proto/com/coralogix/enrichment/v1/enrichment_service.proto
+++ b/proto/com/coralogix/enrichment/v1/enrichment_service.proto
@@ -173,6 +173,18 @@ service EnrichmentService {
     };
   }
 
+    rpc AtomicOverwriteCustomEnrichments(AtomicOverwriteEnrichmentsRequest) returns (AtomicOverwriteEnrichmentsResponse) {
+    option (google.api.http) = {
+      put: "/enrichment-rules/enrichment-rules/v1"
+      body: "*"
+      additional_bindings: {patch: "/enrichments:atomicOverwrite"}
+    };
+    option (grpc.gateway.protoc_gen_openapiv3.options.openapiv3_operation) = {
+      tags: ["Enrichments Service"]
+      summary: "Atomic Overwrite for CustomEnrichments to be used by the UI and external clients"
+    };
+  }
+
   rpc AtomicOverwriteEnrichments(AtomicOverwriteEnrichmentsRequest) returns (AtomicOverwriteEnrichmentsResponse) {
     option (google.api.http) = {
       put: "/enrichment-rules/enrichment-rules/v1"
@@ -181,7 +193,7 @@ service EnrichmentService {
     };
     option (grpc.gateway.protoc_gen_openapiv3.options.openapiv3_operation) = {
       tags: ["Enrichments Service"]
-      summary: "Atomic Overwrite Enrichments"
+      summary: "Atomic Overwrite for ALL types of enrichments. The request is the desired state which will override ALL enrichments. FOR INTERNAL USE ONLY!"
     };
   }
   rpc GetCompanyEnrichmentSettings(GetCompanyEnrichmentSettingsRequest) returns (GetCompanyEnrichmentSettingsResponse) {

--- a/proto/com/coralogix/enrichment/v1/enrichment_service.proto
+++ b/proto/com/coralogix/enrichment/v1/enrichment_service.proto
@@ -193,7 +193,7 @@ service EnrichmentService {
     };
     option (grpc.gateway.protoc_gen_openapiv3.options.openapiv3_operation) = {
       tags: ["Enrichments Service"]
-      summary: "Atomic Overwrite for ALL types of enrichments. The request is the desired state which will override ALL enrichments. FOR INTERNAL USE ONLY!"
+      summary: "Atomic Overwrite for ALL types of enrichments. The request is the desired state which will override ALL enrichments. WARNING: This operation that will delete all existing enrichments and replace them with the provided ones."
     };
   }
   rpc GetCompanyEnrichmentSettings(GetCompanyEnrichmentSettingsRequest) returns (GetCompanyEnrichmentSettingsResponse) {


### PR DESCRIPTION
[CX-33275](https://coralogix.atlassian.net/browse/CX-33275)

added a new endpoint to be used by external clients to only atomic change their custom enrichments and not all enrichments

[CX-33275]: https://coralogix.atlassian.net/browse/CX-33275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ