### PR TITLE
feat: support dataprime queries for dashboards

### DIFF
--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -293,6 +293,12 @@ type GaugeQueryLogs = widgets.Gauge_Query_Logs
 // GaugeQuerySpans is a type for gauge query for spans.
 type GaugeQuerySpans = widgets.Gauge_Query_Spans
 
+// GaugeQueryDataprime is a type for gauge query for dataprime.
+type GaugeQueryDataprime = widgets.Gauge_Query_Dataprime
+
+// GaugeDataprimeQuery is a type for gauge dataprime query.
+type GaugeDataprimeQuery = widgets.Gauge_DataprimeQuery
+
 // GaugeSpansQuery is a type of gauge query for spans.
 type GaugeSpansQuery = widgets.Gauge_SpansQuery
 

--- a/go/openapi/gen/dashboard_service/api/openapi.yaml
+++ b/go/openapi/gen/dashboard_service/api/openapi.yaml
@@ -9997,6 +9997,8 @@ components:
           $ref: "#/components/schemas/TimeFrameSelect"
         visualization:
           $ref: "#/components/schemas/Visualization"
+      required:
+      - queryDefinitions
       type: object
     widgets.Gauge:
       properties:

--- a/go/openapi/gen/dashboard_service/model_widgets_dynamic.go
+++ b/go/openapi/gen/dashboard_service/model_widgets_dynamic.go
@@ -19,11 +19,11 @@ var _ MappedNullable = &WidgetsDynamic{}
 
 // WidgetsDynamic struct for WidgetsDynamic
 type WidgetsDynamic struct {
-	Interpretation *Interpretation `json:"interpretation,omitempty"`
-	Query *DynamicQuery `json:"query,omitempty"`
+	Interpretation   *Interpretation          `json:"interpretation,omitempty"`
+	Query            *DynamicQuery            `json:"query,omitempty"`
 	QueryDefinitions []DynamicQueryDefinition `json:"queryDefinitions,omitempty"`
-	TimeFrame *TimeFrameSelect `json:"timeFrame,omitempty"`
-	Visualization *Visualization `json:"visualization,omitempty"`
+	TimeFrame        *TimeFrameSelect         `json:"timeFrame,omitempty"`
+	Visualization    *Visualization           `json:"visualization,omitempty"`
 }
 
 // NewWidgetsDynamic instantiates a new WidgetsDynamic object
@@ -204,7 +204,7 @@ func (o *WidgetsDynamic) SetVisualization(v Visualization) {
 }
 
 func (o WidgetsDynamic) MarshalJSON() ([]byte, error) {
-	toSerialize,err := o.ToMap()
+	toSerialize, err := o.ToMap()
 	if err != nil {
 		return []byte{}, err
 	}
@@ -266,5 +266,3 @@ func (v *NullableWidgetsDynamic) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }
-
-

--- a/specs/dashboard_service.json
+++ b/specs/dashboard_service.json
@@ -9260,7 +9260,8 @@
           "visualization": {
             "$ref": "#/components/schemas/Visualization"
           }
-        }
+        },
+        "required": ["queryDefinitions"]
       },
       "widgets.Gauge": {
         "type": "object",


### PR DESCRIPTION
This will solve CDS-2798 and PIPEV2-3566 by adding an option to include DataPrime queries to `coralogix_dashboard`. Aims to solve this error:

```
Error: Extract Gauge Query Error
│
│ with module.workflow_monitoring["sendgrid.json"].coralogix_dashboard.workflow_monitoring[0],
│ on ../../modules/workflow_monitoring/dashboard.tf line 32, in resource "coralogix_dashboard" "workflow_monitoring":
│ 32: resource "coralogix_dashboard" "workflow_monitoring" {
│
│ Unknown gauge query type &dashboard_widgets.GaugeQueryModel{Logs:(*dashboard_widgets.GaugeQueryLogsModel)(nil),
│ Metrics:(*dashboard_widgets.GaugeQueryMetricsModel)(nil), Spans:(*dashboard_widgets.GaugeQuerySpansModel)(nil),
│ DataPrime:(*dashboard_widgets.DataPrimeModel)(0x14000409180)}
╵
```