### PR TITLE
CX-41581: keep alert when oneOf variant is unknown

### DIFF
--- a/.github/workflows/go-code-check.yml
+++ b/.github/workflows/go-code-check.yml
@@ -96,3 +96,20 @@ jobs:
           go install google.golang.org/protobuf/cmd/protoc-gen-go
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
           make test-openapi
+  run_openapi_compat:
+    name: "[Go SDK - Linux] OpenAPI Forward-Compat Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install openapi-generator-cli
+        run: npm install -g @openapitools/openapi-generator-cli
+      - name: Run OpenAPI compat fixtures
+        run: bash go/scripts/test_openapi_compat.sh
+      - name: Run forward-compat unit tests
+        run: go test ./go/openapi/forwardcompat/...

--- a/go/openapi/forwardcompat/forward_compat_test.go
+++ b/go/openapi/forwardcompat/forward_compat_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package forwardcompat exercises forward-compatible decoding behavior
+// against the *real* generated alert_definitions_service package, not synthetic
+// compat fixtures. These tests guard against regressions where a server-side
+// addition of a new oneOf variant would crash older SDK clients.
+package forwardcompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	alerts "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/alert_definitions_service"
+)
+
+// A list response that mixes a known alert kind with a server-side new alert
+// kind must decode cleanly. The unknown alert is kept; its AlertDefProperties
+// wrapper exists with all variant pointers nil so callers can detect "I don't
+// understand this one" via GetActualInstance() == nil.
+func TestListAlertDefsResponse_UnknownVariantKeepsAlertWithNilOneOf(t *testing.T) {
+	payload := `{
+		"alertDefs": [
+			{
+				"id": "alert-known",
+				"alertDefProperties": {
+					"name": "known-alert",
+					"logsImmediate": {}
+				}
+			},
+			{
+				"id": "alert-unknown",
+				"alertDefProperties": {
+					"name": "future-alert",
+					"futureKindProps": {"some": "field"}
+				}
+			}
+		]
+	}`
+
+	var resp alerts.ListAlertDefsResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("expected unmarshal to succeed for mixed payload, got: %v", err)
+	}
+
+	if got := len(resp.AlertDefs); got != 2 {
+		t.Fatalf("expected 2 alert defs, got %d", got)
+	}
+
+	known := resp.AlertDefs[0]
+	if known.Id == nil || *known.Id != "alert-known" {
+		t.Fatalf("known alert id mismatch: %+v", known.Id)
+	}
+	if known.AlertDefProperties == nil {
+		t.Fatal("expected known alert to have non-nil AlertDefProperties wrapper")
+	}
+	if known.AlertDefProperties.GetActualInstance() == nil {
+		t.Fatal("expected known alert to resolve to a variant (got GetActualInstance == nil)")
+	}
+	if known.AlertDefProperties.AlertDefPropertiesLogsImmediate == nil {
+		t.Fatal("expected known alert to resolve to AlertDefPropertiesLogsImmediate")
+	}
+
+	unknown := resp.AlertDefs[1]
+	if unknown.Id == nil || *unknown.Id != "alert-unknown" {
+		t.Fatalf("unknown alert id mismatch: %+v", unknown.Id)
+	}
+	if unknown.AlertDefProperties == nil {
+		t.Fatal("expected unknown alert to keep non-nil AlertDefProperties wrapper")
+	}
+	if unknown.AlertDefProperties.GetActualInstance() != nil {
+		t.Fatalf("expected unknown variant to leave GetActualInstance() == nil, got %T",
+			unknown.AlertDefProperties.GetActualInstance())
+	}
+}
+
+// Regression guard: a single standalone unknown-variant AlertDefProperties
+// payload (the GET-by-id case) must also decode without error.
+func TestAlertDefProperties_StandaloneUnknownVariantDecodesAsNil(t *testing.T) {
+	payload := `{"name": "future-alert", "futureKindProps": {"some": "field"}}`
+
+	var props alerts.AlertDefProperties
+	if err := json.Unmarshal([]byte(payload), &props); err != nil {
+		t.Fatalf("expected unmarshal to succeed, got: %v", err)
+	}
+	if props.GetActualInstance() != nil {
+		t.Fatalf("expected GetActualInstance() == nil for unknown variant, got %T",
+			props.GetActualInstance())
+	}
+}
+
+// Regression guard: an all-known list response still resolves variants
+// correctly. Ensures the no-match path didn't accidentally silence valid
+// match paths.
+func TestListAlertDefsResponse_AllKnownVariantsUnchanged(t *testing.T) {
+	payload := `{
+		"alertDefs": [
+			{"id": "a1", "alertDefProperties": {"name": "n1", "logsImmediate": {}}},
+			{"id": "a2", "alertDefProperties": {"name": "n2", "metricThreshold": {"metricFilter": {}, "rules": []}}}
+		]
+	}`
+
+	var resp alerts.ListAlertDefsResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("expected unmarshal to succeed, got: %v", err)
+	}
+	if len(resp.AlertDefs) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(resp.AlertDefs))
+	}
+	if resp.AlertDefs[0].AlertDefProperties == nil ||
+		resp.AlertDefs[0].AlertDefProperties.AlertDefPropertiesLogsImmediate == nil {
+		t.Fatal("expected a1 to resolve to AlertDefPropertiesLogsImmediate")
+	}
+	if resp.AlertDefs[1].AlertDefProperties == nil ||
+		resp.AlertDefs[1].AlertDefProperties.AlertDefPropertiesMetricThreshold == nil {
+		t.Fatal("expected a2 to resolve to AlertDefPropertiesMetricThreshold")
+	}
+}

--- a/go/openapi/gen/actions_service/model_action_execution_request.go
+++ b/go/openapi/gen/actions_service/model_action_execution_request.go
@@ -112,8 +112,8 @@ func (dst *ActionExecutionRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ActionExecutionRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ActionExecutionRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/actions_service/model_action_execution_response.go
+++ b/go/openapi/gen/actions_service/model_action_execution_response.go
@@ -112,8 +112,8 @@ func (dst *ActionExecutionResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ActionExecutionResponse)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ActionExecutionResponse)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/actions_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/actions_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_alert_def_properties.go
+++ b/go/openapi/gen/alert_definitions_service/model_alert_def_properties.go
@@ -372,8 +372,8 @@ func (dst *AlertDefProperties) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(AlertDefProperties)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AlertDefProperties)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_burn_rate_threshold.go
+++ b/go/openapi/gen/alert_definitions_service/model_burn_rate_threshold.go
@@ -86,8 +86,8 @@ func (dst *BurnRateThreshold) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(BurnRateThreshold)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(BurnRateThreshold)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/alert_definitions_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_metric_missing_values.go
+++ b/go/openapi/gen/alert_definitions_service/model_metric_missing_values.go
@@ -86,8 +86,8 @@ func (dst *MetricMissingValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MetricMissingValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MetricMissingValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_metric_time_window.go
+++ b/go/openapi/gen/alert_definitions_service/model_metric_time_window.go
@@ -86,8 +86,8 @@ func (dst *MetricTimeWindow) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MetricTimeWindow)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MetricTimeWindow)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_slo_threshold_type.go
+++ b/go/openapi/gen/alert_definitions_service/model_slo_threshold_type.go
@@ -86,8 +86,8 @@ func (dst *SloThresholdType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SloThresholdType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SloThresholdType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_v3_integration_type.go
+++ b/go/openapi/gen/alert_definitions_service/model_v3_integration_type.go
@@ -86,8 +86,8 @@ func (dst *V3IntegrationType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V3IntegrationType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V3IntegrationType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_events_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/alert_events_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_events_service/model_get_alert_event_response.go
+++ b/go/openapi/gen/alert_events_service/model_get_alert_event_response.go
@@ -86,8 +86,8 @@ func (dst *GetAlertEventResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GetAlertEventResponse)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GetAlertEventResponse)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_alert_scheduler_rule_protobuf_v1_filter.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_alert_scheduler_rule_protobuf_v1_filter.go
@@ -86,8 +86,8 @@ func (dst *AlertSchedulerRuleProtobufV1Filter) UnmarshalJSON(data []byte) error 
 		return fmt.Errorf("data matches more than one schema in oneOf(AlertSchedulerRuleProtobufV1Filter)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AlertSchedulerRuleProtobufV1Filter)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_alert_scheduler_rule_service_get_bulk_alert_scheduler_rule_alert_scheduler_rules_ids_parameter.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_alert_scheduler_rule_service_get_bulk_alert_scheduler_rule_alert_scheduler_rules_ids_parameter.go
@@ -86,8 +86,8 @@ func (dst *AlertSchedulerRuleServiceGetBulkAlertSchedulerRuleAlertSchedulerRules
 		return fmt.Errorf("data matches more than one schema in oneOf(AlertSchedulerRuleServiceGetBulkAlertSchedulerRuleAlertSchedulerRulesIdsParameter)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AlertSchedulerRuleServiceGetBulkAlertSchedulerRuleAlertSchedulerRulesIdsParameter)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_recurring.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_recurring.go
@@ -86,8 +86,8 @@ func (dst *Recurring) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Recurring)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Recurring)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_recurring_dynamic.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_recurring_dynamic.go
@@ -112,8 +112,8 @@ func (dst *RecurringDynamic) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RecurringDynamic)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RecurringDynamic)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_schedule.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_schedule.go
@@ -86,8 +86,8 @@ func (dst *Schedule) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Schedule)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Schedule)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/alert_scheduler_rule_service/model_timeframe.go
+++ b/go/openapi/gen/alert_scheduler_rule_service/model_timeframe.go
@@ -86,8 +86,8 @@ func (dst *Timeframe) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Timeframe)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Timeframe)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/api_keys_admin_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/api_keys_admin_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/api_keys_admin_service/model_owner.go
+++ b/go/openapi/gen/api_keys_admin_service/model_owner.go
@@ -112,8 +112,8 @@ func (dst *Owner) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Owner)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Owner)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/api_keys_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/api_keys_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/api_keys_service/model_owner.go
+++ b/go/openapi/gen/api_keys_service/model_owner.go
@@ -112,8 +112,8 @@ func (dst *Owner) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Owner)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Owner)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/apm_slo_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/apm_slo_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/cases_notification_service/model_delivery_outcome.go
+++ b/go/openapi/gen/cases_notification_service/model_delivery_outcome.go
@@ -86,8 +86,8 @@ func (dst *DeliveryOutcome) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(DeliveryOutcome)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DeliveryOutcome)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/cases_notification_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/cases_notification_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/cases_notification_service/model_notification_delivery.go
+++ b/go/openapi/gen/cases_notification_service/model_notification_delivery.go
@@ -112,8 +112,8 @@ func (dst *NotificationDelivery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(NotificationDelivery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(NotificationDelivery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/cases_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/cases_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/connectors_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/connectors_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_field_information.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_field_information.go
@@ -190,8 +190,8 @@ func (dst *FieldInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FieldInformation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FieldInformation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_integration_details.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_integration_details.go
@@ -86,8 +86,8 @@ func (dst *IntegrationDetails) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IntegrationDetails)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IntegrationDetails)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_integration_revision.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_integration_revision.go
@@ -190,8 +190,8 @@ func (dst *IntegrationRevision) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IntegrationRevision)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IntegrationRevision)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_parameter.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_parameter.go
@@ -190,8 +190,8 @@ func (dst *Parameter) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Parameter)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Parameter)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_registered_instance.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_registered_instance.go
@@ -112,8 +112,8 @@ func (dst *RegisteredInstance) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RegisteredInstance)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RegisteredInstance)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_test_integration_result.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_test_integration_result.go
@@ -86,8 +86,8 @@ func (dst *TestIntegrationResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TestIntegrationResult)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TestIntegrationResult)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/contextual_data_integration_service/model_v1_integration_type.go
+++ b/go/openapi/gen/contextual_data_integration_service/model_v1_integration_type.go
@@ -216,8 +216,8 @@ func (dst *V1IntegrationType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V1IntegrationType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V1IntegrationType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/custom_enrichments_service/model_custom_enrichment_data.go
+++ b/go/openapi/gen/custom_enrichments_service/model_custom_enrichment_data.go
@@ -86,8 +86,8 @@ func (dst *CustomEnrichmentData) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(CustomEnrichmentData)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(CustomEnrichmentData)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/custom_enrichments_service/model_custom_enrichment_service_search_custom_enrichment_data_search_clauses_parameter_inner.go
+++ b/go/openapi/gen/custom_enrichments_service/model_custom_enrichment_service_search_custom_enrichment_data_search_clauses_parameter_inner.go
@@ -86,8 +86,8 @@ func (dst *CustomEnrichmentServiceSearchCustomEnrichmentDataSearchClausesParamet
 		return fmt.Errorf("data matches more than one schema in oneOf(CustomEnrichmentServiceSearchCustomEnrichmentDataSearchClausesParameterInner)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(CustomEnrichmentServiceSearchCustomEnrichmentDataSearchClausesParameterInner)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/custom_enrichments_service/model_file.go
+++ b/go/openapi/gen/custom_enrichments_service/model_file.go
@@ -86,8 +86,8 @@ func (dst *File) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(File)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(File)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/custom_enrichments_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/custom_enrichments_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_folders_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/dashboard_folders_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_action_definition.go
+++ b/go/openapi/gen/dashboard_service/model_action_definition.go
@@ -86,8 +86,8 @@ func (dst *ActionDefinition) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ActionDefinition)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ActionDefinition)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_annotation_source.go
+++ b/go/openapi/gen/dashboard_service/model_annotation_source.go
@@ -190,8 +190,8 @@ func (dst *AnnotationSource) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(AnnotationSource)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AnnotationSource)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_annotation_widget_scope.go
+++ b/go/openapi/gen/dashboard_service/model_annotation_widget_scope.go
@@ -86,8 +86,8 @@ func (dst *AnnotationWidgetScope) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(AnnotationWidgetScope)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AnnotationWidgetScope)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_bar_chart_query.go
+++ b/go/openapi/gen/dashboard_service/model_bar_chart_query.go
@@ -138,8 +138,8 @@ func (dst *BarChartQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(BarChartQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(BarChartQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_color_label_mapping.go
+++ b/go/openapi/gen/dashboard_service/model_color_label_mapping.go
@@ -112,8 +112,8 @@ func (dst *ColorLabelMapping) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ColorLabelMapping)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ColorLabelMapping)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_colors_by.go
+++ b/go/openapi/gen/dashboard_service/model_colors_by.go
@@ -164,8 +164,8 @@ func (dst *ColorsBy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ColorsBy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ColorsBy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_dashboard.go
+++ b/go/openapi/gen/dashboard_service/model_dashboard.go
@@ -294,8 +294,8 @@ func (dst *Dashboard) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Dashboard)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Dashboard)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_data_table_query.go
+++ b/go/openapi/gen/dashboard_service/model_data_table_query.go
@@ -138,8 +138,8 @@ func (dst *DataTableQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(DataTableQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataTableQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_dataprime_source_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_dataprime_source_strategy.go
@@ -112,8 +112,8 @@ func (dst *DataprimeSourceStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(DataprimeSourceStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataprimeSourceStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_display_name_template_variable.go
+++ b/go/openapi/gen/dashboard_service/model_display_name_template_variable.go
@@ -86,8 +86,8 @@ func (dst *DisplayNameTemplateVariable) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(DisplayNameTemplateVariable)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DisplayNameTemplateVariable)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_dynamic_query.go
+++ b/go/openapi/gen/dashboard_service/model_dynamic_query.go
@@ -138,8 +138,8 @@ func (dst *DynamicQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(DynamicQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DynamicQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_equals_selection.go
+++ b/go/openapi/gen/dashboard_service/model_equals_selection.go
@@ -86,8 +86,8 @@ func (dst *EqualsSelection) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(EqualsSelection)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(EqualsSelection)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_event_recurrence_source_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_event_recurrence_source_strategy.go
@@ -86,8 +86,8 @@ func (dst *EventRecurrenceSourceStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(EventRecurrenceSourceStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(EventRecurrenceSourceStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_filter_operator.go
+++ b/go/openapi/gen/dashboard_service/model_filter_operator.go
@@ -86,8 +86,8 @@ func (dst *FilterOperator) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterOperator)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterOperator)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/dashboard_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_filter_source.go
+++ b/go/openapi/gen/dashboard_service/model_filter_source.go
@@ -112,8 +112,8 @@ func (dst *FilterSource) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterSource)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterSource)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_gauge_query.go
+++ b/go/openapi/gen/dashboard_service/model_gauge_query.go
@@ -138,8 +138,8 @@ func (dst *GaugeQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GaugeQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GaugeQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_geomap_aggregation.go
+++ b/go/openapi/gen/dashboard_service/model_geomap_aggregation.go
@@ -164,8 +164,8 @@ func (dst *GeomapAggregation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GeomapAggregation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GeomapAggregation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_geomap_color.go
+++ b/go/openapi/gen/dashboard_service/model_geomap_color.go
@@ -86,8 +86,8 @@ func (dst *GeomapColor) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GeomapColor)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GeomapColor)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_geomap_field_config.go
+++ b/go/openapi/gen/dashboard_service/model_geomap_field_config.go
@@ -86,8 +86,8 @@ func (dst *GeomapFieldConfig) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GeomapFieldConfig)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GeomapFieldConfig)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_heatmap.go
+++ b/go/openapi/gen/dashboard_service/model_heatmap.go
@@ -86,8 +86,8 @@ func (dst *Heatmap) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Heatmap)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Heatmap)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_hexagon_query.go
+++ b/go/openapi/gen/dashboard_service/model_hexagon_query.go
@@ -138,8 +138,8 @@ func (dst *HexagonQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(HexagonQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(HexagonQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_horizontal_bar_chart_query.go
+++ b/go/openapi/gen/dashboard_service/model_horizontal_bar_chart_query.go
@@ -138,8 +138,8 @@ func (dst *HorizontalBarChartQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(HorizontalBarChartQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(HorizontalBarChartQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_horizontal_bar_chart_y_axis_view_by.go
+++ b/go/openapi/gen/dashboard_service/model_horizontal_bar_chart_y_axis_view_by.go
@@ -86,8 +86,8 @@ func (dst *HorizontalBarChartYAxisViewBy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(HorizontalBarChartYAxisViewBy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(HorizontalBarChartYAxisViewBy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_interval_resolution.go
+++ b/go/openapi/gen/dashboard_service/model_interval_resolution.go
@@ -86,8 +86,8 @@ func (dst *IntervalResolution) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IntervalResolution)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IntervalResolution)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_line_chart_query.go
+++ b/go/openapi/gen/dashboard_service/model_line_chart_query.go
@@ -138,8 +138,8 @@ func (dst *LineChartQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(LineChartQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(LineChartQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_logs_aggregation.go
+++ b/go/openapi/gen/dashboard_service/model_logs_aggregation.go
@@ -216,8 +216,8 @@ func (dst *LogsAggregation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(LogsAggregation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(LogsAggregation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_logs_source_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_logs_source_strategy.go
@@ -112,8 +112,8 @@ func (dst *LogsSourceStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(LogsSourceStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(LogsSourceStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_manual_source_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_manual_source_strategy.go
@@ -86,8 +86,8 @@ func (dst *ManualSourceStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ManualSourceStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ManualSourceStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_min_max.go
+++ b/go/openapi/gen/dashboard_service/model_min_max.go
@@ -86,8 +86,8 @@ func (dst *MinMax) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MinMax)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MinMax)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_multi_select_query.go
+++ b/go/openapi/gen/dashboard_service/model_multi_select_query.go
@@ -112,8 +112,8 @@ func (dst *MultiSelectQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MultiSelectQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MultiSelectQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_multi_select_selection.go
+++ b/go/openapi/gen/dashboard_service/model_multi_select_selection.go
@@ -86,8 +86,8 @@ func (dst *MultiSelectSelection) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MultiSelectSelection)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MultiSelectSelection)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_multi_select_source.go
+++ b/go/openapi/gen/dashboard_service/model_multi_select_source.go
@@ -164,8 +164,8 @@ func (dst *MultiSelectSource) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MultiSelectSource)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MultiSelectSource)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_multi_string_value.go
+++ b/go/openapi/gen/dashboard_service/model_multi_string_value.go
@@ -112,8 +112,8 @@ func (dst *MultiStringValue) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(MultiStringValue)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MultiStringValue)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_pie_chart_query.go
+++ b/go/openapi/gen/dashboard_service/model_pie_chart_query.go
@@ -138,8 +138,8 @@ func (dst *PieChartQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(PieChartQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(PieChartQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_property_definition.go
+++ b/go/openapi/gen/dashboard_service/model_property_definition.go
@@ -242,8 +242,8 @@ func (dst *PropertyDefinition) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(PropertyDefinition)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(PropertyDefinition)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_logs_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_logs_query_type.go
@@ -86,8 +86,8 @@ func (dst *QueryLogsQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QueryLogsQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QueryLogsQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_metrics_query_operator.go
+++ b/go/openapi/gen/dashboard_service/model_query_metrics_query_operator.go
@@ -86,8 +86,8 @@ func (dst *QueryMetricsQueryOperator) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QueryMetricsQueryOperator)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QueryMetricsQueryOperator)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_metrics_query_string_or_variable.go
+++ b/go/openapi/gen/dashboard_service/model_query_metrics_query_string_or_variable.go
@@ -86,8 +86,8 @@ func (dst *QueryMetricsQueryStringOrVariable) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QueryMetricsQueryStringOrVariable)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QueryMetricsQueryStringOrVariable)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_metrics_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_metrics_query_type.go
@@ -112,8 +112,8 @@ func (dst *QueryMetricsQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QueryMetricsQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QueryMetricsQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_source_logs_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_source_logs_query_type.go
@@ -86,8 +86,8 @@ func (dst *QuerySourceLogsQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySourceLogsQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySourceLogsQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_source_metrics_query_operator.go
+++ b/go/openapi/gen/dashboard_service/model_query_source_metrics_query_operator.go
@@ -86,8 +86,8 @@ func (dst *QuerySourceMetricsQueryOperator) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySourceMetricsQueryOperator)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySourceMetricsQueryOperator)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_source_metrics_query_string_or_variable.go
+++ b/go/openapi/gen/dashboard_service/model_query_source_metrics_query_string_or_variable.go
@@ -86,8 +86,8 @@ func (dst *QuerySourceMetricsQueryStringOrVariable) UnmarshalJSON(data []byte) e
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySourceMetricsQueryStringOrVariable)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySourceMetricsQueryStringOrVariable)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_source_metrics_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_source_metrics_query_type.go
@@ -112,8 +112,8 @@ func (dst *QuerySourceMetricsQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySourceMetricsQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySourceMetricsQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_source_spans_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_source_spans_query_type.go
@@ -86,8 +86,8 @@ func (dst *QuerySourceSpansQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySourceSpansQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySourceSpansQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_query_spans_query_type.go
+++ b/go/openapi/gen/dashboard_service/model_query_spans_query_type.go
@@ -86,8 +86,8 @@ func (dst *QuerySpansQueryType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(QuerySpansQueryType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(QuerySpansQueryType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_rule_scope.go
+++ b/go/openapi/gen/dashboard_service/model_rule_scope.go
@@ -112,8 +112,8 @@ func (dst *RuleScope) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RuleScope)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RuleScope)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_section_options.go
+++ b/go/openapi/gen/dashboard_service/model_section_options.go
@@ -86,8 +86,8 @@ func (dst *SectionOptions) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SectionOptions)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SectionOptions)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_sort_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_sort_strategy.go
@@ -86,8 +86,8 @@ func (dst *SortStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SortStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SortStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_span_field.go
+++ b/go/openapi/gen/dashboard_service/model_span_field.go
@@ -112,8 +112,8 @@ func (dst *SpanField) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SpanField)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SpanField)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_spans_aggregation.go
+++ b/go/openapi/gen/dashboard_service/model_spans_aggregation.go
@@ -86,8 +86,8 @@ func (dst *SpansAggregation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SpansAggregation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SpansAggregation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_spans_source_strategy.go
+++ b/go/openapi/gen/dashboard_service/model_spans_source_strategy.go
@@ -112,8 +112,8 @@ func (dst *SpansSourceStrategy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SpansSourceStrategy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SpansSourceStrategy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_stat_visual_element.go
+++ b/go/openapi/gen/dashboard_service/model_stat_visual_element.go
@@ -86,8 +86,8 @@ func (dst *StatVisualElement) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(StatVisualElement)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(StatVisualElement)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_textbox_default_value.go
+++ b/go/openapi/gen/dashboard_service/model_textbox_default_value.go
@@ -216,8 +216,8 @@ func (dst *TextboxDefaultValue) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TextboxDefaultValue)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TextboxDefaultValue)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_time_frame_select.go
+++ b/go/openapi/gen/dashboard_service/model_time_frame_select.go
@@ -86,8 +86,8 @@ func (dst *TimeFrameSelect) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TimeFrameSelect)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TimeFrameSelect)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_variable_definition.go
+++ b/go/openapi/gen/dashboard_service/model_variable_definition.go
@@ -86,8 +86,8 @@ func (dst *VariableDefinition) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(VariableDefinition)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(VariableDefinition)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_variable_source_v2.go
+++ b/go/openapi/gen/dashboard_service/model_variable_source_v2.go
@@ -112,8 +112,8 @@ func (dst *VariableSourceV2) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(VariableSourceV2)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(VariableSourceV2)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_variable_source_v2_query_source.go
+++ b/go/openapi/gen/dashboard_service/model_variable_source_v2_query_source.go
@@ -138,8 +138,8 @@ func (dst *VariableSourceV2QuerySource) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(VariableSourceV2QuerySource)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(VariableSourceV2QuerySource)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_variable_value_v2.go
+++ b/go/openapi/gen/dashboard_service/model_variable_value_v2.go
@@ -190,8 +190,8 @@ func (dst *VariableValueV2) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(VariableValueV2)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(VariableValueV2)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_visualization.go
+++ b/go/openapi/gen/dashboard_service/model_visualization.go
@@ -424,8 +424,8 @@ func (dst *Visualization) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Visualization)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Visualization)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_widget_definition.go
+++ b/go/openapi/gen/dashboard_service/model_widget_definition.go
@@ -268,8 +268,8 @@ func (dst *WidgetDefinition) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(WidgetDefinition)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(WidgetDefinition)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/dashboard_service/model_x_axis.go
+++ b/go/openapi/gen/dashboard_service/model_x_axis.go
@@ -112,8 +112,8 @@ func (dst *XAxis) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(XAxis)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(XAxis)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_evaluation_tokens_request.go
+++ b/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_evaluation_tokens_request.go
@@ -86,8 +86,8 @@ func (dst *DataUsageServiceGetDailyUsageEvaluationTokensRequest) UnmarshalJSON(d
 		return fmt.Errorf("data matches more than one schema in oneOf(DataUsageServiceGetDailyUsageEvaluationTokensRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataUsageServiceGetDailyUsageEvaluationTokensRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_processed_gbs_request.go
+++ b/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_processed_gbs_request.go
@@ -86,8 +86,8 @@ func (dst *DataUsageServiceGetDailyUsageProcessedGbsRequest) UnmarshalJSON(data 
 		return fmt.Errorf("data matches more than one schema in oneOf(DataUsageServiceGetDailyUsageProcessedGbsRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataUsageServiceGetDailyUsageProcessedGbsRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_units_request.go
+++ b/go/openapi/gen/data_usage_service/model_data_usage_service_get_daily_usage_units_request.go
@@ -86,8 +86,8 @@ func (dst *DataUsageServiceGetDailyUsageUnitsRequest) UnmarshalJSON(data []byte)
 		return fmt.Errorf("data matches more than one schema in oneOf(DataUsageServiceGetDailyUsageUnitsRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataUsageServiceGetDailyUsageUnitsRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_data_usage_service_get_data_usage_dimension_filters_parameter_inner.go
+++ b/go/openapi/gen/data_usage_service/model_data_usage_service_get_data_usage_dimension_filters_parameter_inner.go
@@ -164,8 +164,8 @@ func (dst *DataUsageServiceGetDataUsageDimensionFiltersParameterInner) Unmarshal
 		return fmt.Errorf("data matches more than one schema in oneOf(DataUsageServiceGetDataUsageDimensionFiltersParameterInner)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(DataUsageServiceGetDataUsageDimensionFiltersParameterInner)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_dimension.go
+++ b/go/openapi/gen/data_usage_service/model_dimension.go
@@ -164,8 +164,8 @@ func (dst *Dimension) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Dimension)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Dimension)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/data_usage_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/data_usage_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/enrichments_service/model_enrichment_type.go
+++ b/go/openapi/gen/enrichments_service/model_enrichment_type.go
@@ -138,8 +138,8 @@ func (dst *EnrichmentType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(EnrichmentType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(EnrichmentType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/enrichments_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/enrichments_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/entities_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/entities_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_e2_m.go
+++ b/go/openapi/gen/events2metrics_service/model_e2_m.go
@@ -86,8 +86,8 @@ func (dst *E2M) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(E2M)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(E2M)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_e2_m_create_params.go
+++ b/go/openapi/gen/events2metrics_service/model_e2_m_create_params.go
@@ -86,8 +86,8 @@ func (dst *E2MCreateParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(E2MCreateParams)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(E2MCreateParams)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_e2_m_execution_request.go
+++ b/go/openapi/gen/events2metrics_service/model_e2_m_execution_request.go
@@ -112,8 +112,8 @@ func (dst *E2MExecutionRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(E2MExecutionRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(E2MExecutionRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_e2_m_execution_response.go
+++ b/go/openapi/gen/events2metrics_service/model_e2_m_execution_response.go
@@ -112,8 +112,8 @@ func (dst *E2MExecutionResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(E2MExecutionResponse)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(E2MExecutionResponse)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_events2_metric_service_create_e2_m_request.go
+++ b/go/openapi/gen/events2metrics_service/model_events2_metric_service_create_e2_m_request.go
@@ -86,8 +86,8 @@ func (dst *Events2MetricServiceCreateE2MRequest) UnmarshalJSON(data []byte) erro
 		return fmt.Errorf("data matches more than one schema in oneOf(Events2MetricServiceCreateE2MRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Events2MetricServiceCreateE2MRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_events2_metric_service_replace_e2_m_request.go
+++ b/go/openapi/gen/events2metrics_service/model_events2_metric_service_replace_e2_m_request.go
@@ -86,8 +86,8 @@ func (dst *Events2MetricServiceReplaceE2MRequest) UnmarshalJSON(data []byte) err
 		return fmt.Errorf("data matches more than one schema in oneOf(Events2MetricServiceReplaceE2MRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Events2MetricServiceReplaceE2MRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/events2metrics_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events2metrics_service/model_v2_aggregation.go
+++ b/go/openapi/gen/events2metrics_service/model_v2_aggregation.go
@@ -112,8 +112,8 @@ func (dst *V2Aggregation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V2Aggregation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V2Aggregation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events_service/model_cx_event_single_or_multiple.go
+++ b/go/openapi/gen/events_service/model_cx_event_single_or_multiple.go
@@ -86,8 +86,8 @@ func (dst *CxEventSingleOrMultiple) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(CxEventSingleOrMultiple)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(CxEventSingleOrMultiple)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/events_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/events_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/extension_deployment_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/extension_deployment_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/extension_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/extension_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/extension_testing_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/extension_testing_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/folders_for_views_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/folders_for_views_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/global_routers_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/global_routers_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/incidents_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_group_by_values.go
+++ b/go/openapi/gen/incidents_service/model_group_by_values.go
@@ -86,8 +86,8 @@ func (dst *GroupByValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(GroupByValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(GroupByValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_incident_event.go
+++ b/go/openapi/gen/incidents_service/model_incident_event.go
@@ -346,8 +346,8 @@ func (dst *IncidentEvent) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IncidentEvent)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IncidentEvent)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_incident_field_one_of.go
+++ b/go/openapi/gen/incidents_service/model_incident_field_one_of.go
@@ -320,8 +320,8 @@ func (dst *IncidentFieldOneOf) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IncidentFieldOneOf)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IncidentFieldOneOf)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_incident_search_query.go
+++ b/go/openapi/gen/incidents_service/model_incident_search_query.go
@@ -86,8 +86,8 @@ func (dst *IncidentSearchQuery) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IncidentSearchQuery)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IncidentSearchQuery)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_incidents_service_list_incident_aggregations_group_bys_parameter_inner.go
+++ b/go/openapi/gen/incidents_service/model_incidents_service_list_incident_aggregations_group_bys_parameter_inner.go
@@ -86,8 +86,8 @@ func (dst *IncidentsServiceListIncidentAggregationsGroupBysParameterInner) Unmar
 		return fmt.Errorf("data matches more than one schema in oneOf(IncidentsServiceListIncidentAggregationsGroupBysParameterInner)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IncidentsServiceListIncidentAggregationsGroupBysParameterInner)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/incidents_service/model_v1_order_by.go
+++ b/go/openapi/gen/incidents_service/model_v1_order_by.go
@@ -86,8 +86,8 @@ func (dst *V1OrderBy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V1OrderBy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V1OrderBy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_field_information.go
+++ b/go/openapi/gen/integration_service/model_field_information.go
@@ -190,8 +190,8 @@ func (dst *FieldInformation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FieldInformation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FieldInformation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/integration_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_integration_details.go
+++ b/go/openapi/gen/integration_service/model_integration_details.go
@@ -86,8 +86,8 @@ func (dst *IntegrationDetails) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IntegrationDetails)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IntegrationDetails)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_integration_revision.go
+++ b/go/openapi/gen/integration_service/model_integration_revision.go
@@ -190,8 +190,8 @@ func (dst *IntegrationRevision) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IntegrationRevision)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IntegrationRevision)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_parameter.go
+++ b/go/openapi/gen/integration_service/model_parameter.go
@@ -190,8 +190,8 @@ func (dst *Parameter) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Parameter)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Parameter)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_registered_instance.go
+++ b/go/openapi/gen/integration_service/model_registered_instance.go
@@ -112,8 +112,8 @@ func (dst *RegisteredInstance) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RegisteredInstance)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RegisteredInstance)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_test_integration_result.go
+++ b/go/openapi/gen/integration_service/model_test_integration_result.go
@@ -86,8 +86,8 @@ func (dst *TestIntegrationResult) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TestIntegrationResult)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TestIntegrationResult)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/integration_service/model_v1_integration_type.go
+++ b/go/openapi/gen/integration_service/model_v1_integration_type.go
@@ -216,8 +216,8 @@ func (dst *V1IntegrationType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V1IntegrationType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V1IntegrationType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/ip_access_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/ip_access_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/metrics_data_archive_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/metrics_data_archive_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_configure_tenant_request.go
+++ b/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_configure_tenant_request.go
@@ -112,8 +112,8 @@ func (dst *MetricsConfiguratorPublicServiceConfigureTenantRequest) UnmarshalJSON
 		return fmt.Errorf("data matches more than one schema in oneOf(MetricsConfiguratorPublicServiceConfigureTenantRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MetricsConfiguratorPublicServiceConfigureTenantRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_update_request.go
+++ b/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_update_request.go
@@ -112,8 +112,8 @@ func (dst *MetricsConfiguratorPublicServiceUpdateRequest) UnmarshalJSON(data []b
 		return fmt.Errorf("data matches more than one schema in oneOf(MetricsConfiguratorPublicServiceUpdateRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MetricsConfiguratorPublicServiceUpdateRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_validate_bucket_request.go
+++ b/go/openapi/gen/metrics_data_archive_service/model_metrics_configurator_public_service_validate_bucket_request.go
@@ -112,8 +112,8 @@ func (dst *MetricsConfiguratorPublicServiceValidateBucketRequest) UnmarshalJSON(
 		return fmt.Errorf("data matches more than one schema in oneOf(MetricsConfiguratorPublicServiceValidateBucketRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(MetricsConfiguratorPublicServiceValidateBucketRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/metrics_data_archive_service/model_tenant_config_v2.go
+++ b/go/openapi/gen/metrics_data_archive_service/model_tenant_config_v2.go
@@ -112,8 +112,8 @@ func (dst *TenantConfigV2) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TenantConfigV2)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TenantConfigV2)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/outgoing_webhooks_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/outgoing_webhooks_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/outgoing_webhooks_service/model_outgoing_webhook.go
+++ b/go/openapi/gen/outgoing_webhooks_service/model_outgoing_webhook.go
@@ -346,8 +346,8 @@ func (dst *OutgoingWebhook) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(OutgoingWebhook)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(OutgoingWebhook)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/outgoing_webhooks_service/model_outgoing_webhook_input_data.go
+++ b/go/openapi/gen/outgoing_webhooks_service/model_outgoing_webhook_input_data.go
@@ -346,8 +346,8 @@ func (dst *OutgoingWebhookInputData) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(OutgoingWebhookInputData)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(OutgoingWebhookInputData)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/outgoing_webhooks_service/model_test_outgoing_webhook_response.go
+++ b/go/openapi/gen/outgoing_webhooks_service/model_test_outgoing_webhook_response.go
@@ -86,8 +86,8 @@ func (dst *TestOutgoingWebhookResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TestOutgoingWebhookResponse)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TestOutgoingWebhookResponse)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/policies_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/policies_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/policies_service/model_placement.go
+++ b/go/openapi/gen/policies_service/model_placement.go
@@ -86,8 +86,8 @@ func (dst *Placement) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Placement)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Placement)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/policies_service/model_policies_service_create_policy_request.go
+++ b/go/openapi/gen/policies_service/model_policies_service_create_policy_request.go
@@ -86,8 +86,8 @@ func (dst *PoliciesServiceCreatePolicyRequest) UnmarshalJSON(data []byte) error 
 		return fmt.Errorf("data matches more than one schema in oneOf(PoliciesServiceCreatePolicyRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(PoliciesServiceCreatePolicyRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/policies_service/model_policies_service_update_policy_request.go
+++ b/go/openapi/gen/policies_service/model_policies_service_update_policy_request.go
@@ -86,8 +86,8 @@ func (dst *PoliciesServiceUpdatePolicyRequest) UnmarshalJSON(data []byte) error 
 		return fmt.Errorf("data matches more than one schema in oneOf(PoliciesServiceUpdatePolicyRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(PoliciesServiceUpdatePolicyRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/policies_service/model_policy.go
+++ b/go/openapi/gen/policies_service/model_policy.go
@@ -86,8 +86,8 @@ func (dst *Policy) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Policy)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Policy)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/presets_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/presets_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/presets_service/model_notification_center_condition_type.go
+++ b/go/openapi/gen/presets_service/model_notification_center_condition_type.go
@@ -86,8 +86,8 @@ func (dst *NotificationCenterConditionType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(NotificationCenterConditionType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(NotificationCenterConditionType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/quota_allocation_rule_set_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/quota_allocation_rule_set_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/recording_rules_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/recording_rules_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/retentions_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/retentions_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/role_management_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/role_management_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/role_management_service/model_role_management_service_create_role_request.go
+++ b/go/openapi/gen/role_management_service/model_role_management_service_create_role_request.go
@@ -86,8 +86,8 @@ func (dst *RoleManagementServiceCreateRoleRequest) UnmarshalJSON(data []byte) er
 		return fmt.Errorf("data matches more than one schema in oneOf(RoleManagementServiceCreateRoleRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RoleManagementServiceCreateRoleRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/rule_groups_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/rule_groups_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/rule_groups_service/model_rule_matcher.go
+++ b/go/openapi/gen/rule_groups_service/model_rule_matcher.go
@@ -112,8 +112,8 @@ func (dst *RuleMatcher) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RuleMatcher)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RuleMatcher)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/rule_groups_service/model_rule_parameters.go
+++ b/go/openapi/gen/rule_groups_service/model_rule_parameters.go
@@ -294,8 +294,8 @@ func (dst *RuleParameters) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RuleParameters)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RuleParameters)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/saml_configuration_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/saml_configuration_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/saml_configuration_service/model_idp_parameters.go
+++ b/go/openapi/gen/saml_configuration_service/model_idp_parameters.go
@@ -86,8 +86,8 @@ func (dst *IDPParameters) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(IDPParameters)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(IDPParameters)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/scopes_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/scopes_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_apm_latency_sli.go
+++ b/go/openapi/gen/slos_service/model_apm_latency_sli.go
@@ -86,8 +86,8 @@ func (dst *ApmLatencySli) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ApmLatencySli)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ApmLatencySli)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_apm_sli.go
+++ b/go/openapi/gen/slos_service/model_apm_sli.go
@@ -86,8 +86,8 @@ func (dst *ApmSli) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ApmSli)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ApmSli)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/slos_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slo.go
+++ b/go/openapi/gen/slos_service/model_slo.go
@@ -112,8 +112,8 @@ func (dst *Slo) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(Slo)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(Slo)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slo_execution_request.go
+++ b/go/openapi/gen/slos_service/model_slo_execution_request.go
@@ -112,8 +112,8 @@ func (dst *SloExecutionRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SloExecutionRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SloExecutionRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slo_execution_response.go
+++ b/go/openapi/gen/slos_service/model_slo_execution_response.go
@@ -112,8 +112,8 @@ func (dst *SloExecutionResponse) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SloExecutionResponse)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SloExecutionResponse)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slo_filter_field.go
+++ b/go/openapi/gen/slos_service/model_slo_filter_field.go
@@ -164,8 +164,8 @@ func (dst *SloFilterField) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SloFilterField)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SloFilterField)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slo_filter_predicate_is.go
+++ b/go/openapi/gen/slos_service/model_slo_filter_predicate_is.go
@@ -112,8 +112,8 @@ func (dst *SloFilterPredicateIs) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SloFilterPredicateIs)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SloFilterPredicateIs)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slos_service_create_slo_request.go
+++ b/go/openapi/gen/slos_service/model_slos_service_create_slo_request.go
@@ -112,8 +112,8 @@ func (dst *SlosServiceCreateSloRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SlosServiceCreateSloRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SlosServiceCreateSloRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/slos_service/model_slos_service_replace_slo_request.go
+++ b/go/openapi/gen/slos_service/model_slos_service_replace_slo_request.go
@@ -112,8 +112,8 @@ func (dst *SlosServiceReplaceSloRequest) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(SlosServiceReplaceSloRequest)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(SlosServiceReplaceSloRequest)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/target_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/target_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/target_service/model_v2_target.go
+++ b/go/openapi/gen/target_service/model_v2_target.go
@@ -86,8 +86,8 @@ func (dst *V2Target) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(V2Target)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(V2Target)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/team_groups_management_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/team_groups_management_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/team_groups_management_service/model_role_update_action.go
+++ b/go/openapi/gen/team_groups_management_service/model_role_update_action.go
@@ -86,8 +86,8 @@ func (dst *RoleUpdateAction) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(RoleUpdateAction)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(RoleUpdateAction)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/team_groups_management_service/model_scope_update_action.go
+++ b/go/openapi/gen/team_groups_management_service/model_scope_update_action.go
@@ -86,8 +86,8 @@ func (dst *ScopeUpdateAction) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(ScopeUpdateAction)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(ScopeUpdateAction)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/team_groups_management_service/model_user_updates_operation.go
+++ b/go/openapi/gen/team_groups_management_service/model_user_updates_operation.go
@@ -112,8 +112,8 @@ func (dst *UserUpdatesOperation) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(UserUpdatesOperation)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(UserUpdatesOperation)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/testing_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/testing_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/users_management_service/model_access_type.go
+++ b/go/openapi/gen/users_management_service/model_access_type.go
@@ -86,8 +86,8 @@ func (dst *AccessType) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(AccessType)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(AccessType)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/users_management_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/users_management_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/views_service/model_filter_path_and_values.go
+++ b/go/openapi/gen/views_service/model_filter_path_and_values.go
@@ -86,8 +86,8 @@ func (dst *FilterPathAndValues) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(FilterPathAndValues)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(FilterPathAndValues)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/gen/views_service/model_time_selection.go
+++ b/go/openapi/gen/views_service/model_time_selection.go
@@ -86,8 +86,8 @@ func (dst *TimeSelection) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf(TimeSelection)")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf(TimeSelection)")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 }
 

--- a/go/openapi/templates/model_oneof.mustache
+++ b/go/openapi/templates/model_oneof.mustache
@@ -78,8 +78,8 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf({{classname}})")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 	{{/discriminator}}
 	{{/useOneOfDiscriminatorLookup}}
@@ -113,8 +113,8 @@ func (dst *{{classname}}) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("data matches more than one schema in oneOf({{classname}})")
 	} else if match == 1 {
 		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("data failed to match schemas in oneOf({{classname}})")
+	} else { // no match — preserve forward-compat by leaving all variant pointers nil
+		return nil
 	}
 	{{/useOneOfDiscriminatorLookup}}
 }

--- a/go/openapi/testdata/compat/forward-compat-oneof/compat_test.go
+++ b/go/openapi/testdata/compat/forward-compat-oneof/compat_test.go
@@ -1,0 +1,99 @@
+package forward_compat_oneof
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// When the server returns a list response containing an unknown oneOf variant
+// (e.g. a brand-new alert kind shipped by the backend before the SDK knows
+// about it), decoding must succeed and the unknown element must keep its
+// sibling fields. The unknown oneOf field itself is left with all variant
+// pointers nil — callers can detect this via GetActualInstance() == nil.
+func TestForwardCompatOneOf_UnknownVariantInListKeepsAlertWithNilOneOf(t *testing.T) {
+	payload := `{
+		"alerts": [
+			{"id": "alert-known", "alertProps": {"logFilter": "level:error"}},
+			{"id": "alert-unknown", "alertProps": {"futureVariant": {"foo": "bar"}}}
+		]
+	}`
+
+	var resp ListAlertsResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("expected unmarshal to succeed, got: %v", err)
+	}
+
+	if len(resp.Alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(resp.Alerts))
+	}
+
+	known := resp.Alerts[0]
+	if known.Id != "alert-known" {
+		t.Fatalf("known alert id mismatch: %q", known.Id)
+	}
+	if known.AlertProps == nil || known.AlertProps.LogsImmediateProps == nil {
+		t.Fatalf("expected known alert to decode LogsImmediateProps, got %+v", known.AlertProps)
+	}
+	if known.AlertProps.MetricThresholdProps != nil {
+		t.Fatalf("expected MetricThresholdProps to remain nil")
+	}
+
+	unknown := resp.Alerts[1]
+	if unknown.Id != "alert-unknown" {
+		t.Fatalf("unknown alert id mismatch: %q", unknown.Id)
+	}
+	if unknown.AlertProps == nil {
+		t.Fatalf("expected unknown alert to keep AlertProps wrapper (non-nil), got nil")
+	}
+	if unknown.AlertProps.GetActualInstance() != nil {
+		t.Fatalf("expected unknown variant to leave GetActualInstance() == nil")
+	}
+	if unknown.AlertProps.LogsImmediateProps != nil || unknown.AlertProps.MetricThresholdProps != nil {
+		t.Fatalf("expected all variant pointers to remain nil for unknown variant")
+	}
+}
+
+// Regression guard: an all-known payload must still resolve variants exactly
+// as before this change.
+func TestForwardCompatOneOf_AllKnownVariantsUnchanged(t *testing.T) {
+	payload := `{
+		"alerts": [
+			{"id": "a1", "alertProps": {"logFilter": "level:error"}},
+			{"id": "a2", "alertProps": {"metricFilter": "rate(http_requests_total)"}}
+		]
+	}`
+
+	var resp ListAlertsResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("expected unmarshal to succeed, got: %v", err)
+	}
+	if len(resp.Alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(resp.Alerts))
+	}
+
+	if resp.Alerts[0].AlertProps == nil || resp.Alerts[0].AlertProps.LogsImmediateProps == nil {
+		t.Fatal("expected a1 to resolve to LogsImmediateProps")
+	}
+	if resp.Alerts[1].AlertProps == nil || resp.Alerts[1].AlertProps.MetricThresholdProps == nil {
+		t.Fatal("expected a2 to resolve to MetricThresholdProps")
+	}
+}
+
+// Decoding a *single* unknown-variant oneOf (not nested in a list) must also
+// succeed cleanly — the fix applies at the oneOf level and is symmetric across
+// GET-by-id and LIST endpoints.
+func TestForwardCompatOneOf_StandaloneUnknownVariantDecodesAsNil(t *testing.T) {
+	payload := `{"futureVariant": {"foo": "bar"}}`
+
+	var props AlertProps
+	if err := json.Unmarshal([]byte(payload), &props); err != nil {
+		t.Fatalf("expected unmarshal to succeed, got: %v", err)
+	}
+	if props.GetActualInstance() != nil {
+		t.Fatalf("expected GetActualInstance() == nil for unknown variant")
+	}
+	if props.LogsImmediateProps != nil || props.MetricThresholdProps != nil {
+		t.Fatalf("expected all variant pointers to remain nil")
+	}
+}

--- a/go/openapi/testdata/compat/forward-compat-oneof/openapi.yaml
+++ b/go/openapi/testdata/compat/forward-compat-oneof/openapi.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.3
+info:
+  title: Forward-Compat OneOf
+  version: 1.0.0
+paths:
+  /alerts:
+    get:
+      operationId: listAlerts
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAlertsResponse"
+components:
+  schemas:
+    ListAlertsResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - alerts
+      properties:
+        alerts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Alert"
+    Alert:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        alertProps:
+          $ref: "#/components/schemas/AlertProps"
+    AlertProps:
+      oneOf:
+        - $ref: "#/components/schemas/LogsImmediateProps"
+        - $ref: "#/components/schemas/MetricThresholdProps"
+    LogsImmediateProps:
+      type: object
+      additionalProperties: false
+      required:
+        - logFilter
+      properties:
+        logFilter:
+          type: string
+    MetricThresholdProps:
+      type: object
+      additionalProperties: false
+      required:
+        - metricFilter
+      properties:
+        metricFilter:
+          type: string

--- a/go/scripts/test_openapi_compat.sh
+++ b/go/scripts/test_openapi_compat.sh
@@ -73,5 +73,21 @@ for fixture_dir in "$FIXTURES_DIR"/*; do
     --global-property=apiTests=false,modelTests=false,apiDocs=false,modelDocs=false >/dev/null
 
   cp "$fixture_dir/compat_test.go" "$outdir/compat_test.go"
+
+  # Models with `additionalProperties: false` + required fields can emit a
+  # duplicate `"bytes"` import. goimports cleans this up so each fixture
+  # compiles. Install on demand if the binary isn't already available.
+  if ! command -v goimports >/dev/null 2>&1; then
+    GOPATH_BIN="$(go env GOPATH)/bin"
+    if [ ! -x "$GOPATH_BIN/goimports" ]; then
+      go install golang.org/x/tools/cmd/goimports@latest >/dev/null 2>&1 || true
+    fi
+    if [ -x "$GOPATH_BIN/goimports" ]; then
+      "$GOPATH_BIN/goimports" -w "$outdir"
+    fi
+  else
+    goimports -w "$outdir"
+  fi
+
   (cd "$REPO_ROOT" && go test "./${outdir#$REPO_ROOT/}")
 done


### PR DESCRIPTION
## Problem

When the server adds a new oneOf variant (e.g. a brand-new alert kind), older SDKs return `data failed to match schemas in oneOf(...)` from the oneOf's `UnmarshalJSON`. That error propagates through the parent struct, through `[]AlertDef` element decode, and out of `ListAlertDefsResponse.UnmarshalJSON` — leaving callers unable to read **any** of their alerts.

Jira: [CX-41581](https://coralogix.atlassian.net/browse/CX-41581).

## Fix

Two-line behavior change in `model_oneof.mustache`: on no-match, return `nil` instead of `fmt.Errorf(...)`. The wrapper struct exists with all variant pointers nil; callers detect "unknown" via `GetActualInstance() == nil`.

```diff
- } else { // no match
-     return fmt.Errorf("data failed to match schemas in oneOf(...)")
+ } else { // no match — preserve forward-compat by leaving all variant pointers nil
+     return nil
  }
```

What stays strict on purpose:
- **Ambiguous matches (>1)** — still errors. Real server/spec bug, not forward-compat.
- **Discriminator path with malformed body** — still errors. Server-side bug worth surfacing.

Symmetric across `LIST` and `GET`: a single unknown-variant payload decodes the same way — sibling fields populated, oneOf wrapper has `GetActualInstance() == nil`.

## Tests

- New compat fixture `forward-compat-oneof` proves unknown variant inside a list keeps the alert with nil oneOf, all-known payload unchanged, standalone unknown decodes cleanly.
- New `go/openapi/forwardcompat/` Go package exercises the same against the real generated `alert_definitions_service` types.
- New CI job `run_openapi_compat` runs both (no credentials needed) on every PR.
- `test_openapi_compat.sh` now runs `goimports -w` post-generation to clean a pre-existing duplicate `"bytes"` import that prevented the harness from passing locally.

## Tradeoffs

- Re-marshalling an unknown-variant alert emits `"alertDefProperties": null` (raw bytes not preserved). The ticket explicitly accepts this.
- Callers that dereference variant pointers without nil-check will panic on unknown variants. They should already nil-check today — the oneOf API has always required it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-41581]: https://coralogix.atlassian.net/browse/CX-41581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ