### PR TITLE
ci: rewrite openapi-generate-clients.yml to auto-sync SDK from openapi-facade

### DIFF
--- a/.github/workflows/openapi-generate-clients.yml
+++ b/.github/workflows/openapi-generate-clients.yml
@@ -1,22 +1,41 @@
 name: Generate OpenAPI Clients
 
+# TODO: rename file to sync-latest-spec.yaml and workflow to
+# "Sync and Generate OpenAPI SDK" once this branch has been verified
+# end-to-end. Filename is kept the same as on master so the new
+# workflow_dispatch path is discoverable when triggering from this
+# branch (workflow_dispatch only fires from files that exist on the
+# default branch at the same path).
+#
+# Triggered by openapi-facade's notify-spec-consumers.yml workflow
+# (event_type: facade-spec-updated) whenever may26/openapi.yaml changes
+# on master, or manually via workflow_dispatch. Fetches the spec from
+# openapi-facade at the dispatched commit, runs the split tool +
+# Go OpenAPI generator, and opens a PR with the regenerated clients.
+
 on:
+  repository_dispatch:
+    types: [facade-spec-updated]
+
   workflow_dispatch:
     inputs:
-      specDownloadUrl:
-        description: 'URL to get the OpenAPI.yaml'
+      facade_ref:
+        description: 'openapi-facade ref (commit SHA or branch). Leave empty to use master HEAD.'
         required: false
-  pull_request:
-    paths:
-      - 'openapi.yaml'
+        type: string
+        default: ''
 
 permissions:
   contents: write
   pull-requests: write
 
+env:
+  FACADE_REPO: coralogix/openapi-facade
+  FACADE_SPEC_PATH: may26/openapi.yaml
+
 jobs:
-  generate-openapi:
-    name: Split & Generate Clients
+  sync:
+    name: Sync spec & generate SDK
     runs-on: ubuntu-latest
 
     steps:
@@ -24,14 +43,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: curl
-        uses: sozo-design/curl@v1.0.2
-        with:
-          args: ${{ inputs.specDownloadUrl }} -o openapi.yaml
-        if: ${{ inputs.specDownloadUrl }}
+      - name: Resolve openapi-facade ref
+        id: facade
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          DISPATCH_SHA="${{ github.event.client_payload.commit_sha }}"
+          INPUT_REF="${{ github.event.inputs.facade_ref }}"
+          if [ -n "$DISPATCH_SHA" ]; then
+            REF="$DISPATCH_SHA"
+          elif [ -n "$INPUT_REF" ]; then
+            REF="$INPUT_REF"
+          else
+            REF=$(gh api "repos/${FACADE_REPO}/commits/master" --jq .sha)
+          fi
+          if [ -z "$REF" ]; then
+            echo "::error::Could not resolve openapi-facade ref"
+            exit 1
+          fi
+          SHA=$(gh api "repos/${FACADE_REPO}/commits/${REF}" --jq .sha)
+          echo "Using openapi-facade SHA: $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch openapi.yaml from openapi-facade
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          # Raw media type so files >1MB don't come back base64-empty.
+          gh api -H "Accept: application/vnd.github.raw" \
+            "repos/${FACADE_REPO}/contents/${FACADE_SPEC_PATH}?ref=${{ steps.facade.outputs.sha }}" \
+            > openapi.yaml
+          if [ ! -s openapi.yaml ]; then
+            echo "::error::Fetched openapi.yaml is empty"
+            exit 1
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -46,25 +93,50 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install Redocly CLI
+      - name: Install Redocly + OpenAPI Generator CLIs
         run: |
           npm install -g @redocly/cli@latest
           npm install -g @openapitools/openapi-generator-cli
           openapi-generator-cli version
 
-      - name: Run OpenAPI Split Tool
+      - name: Run OpenAPI split tool
         run: |
           rm -Rf specs
           chmod +x ./tools/openapi-split/split_specs.sh
           ./tools/openapi-split/split_specs.sh
 
-      - name: Generate Go Client
+      - name: Generate Go OpenAPI client
         run: |
           chmod +x ./go/scripts/generate_openapi.sh
           ./go/scripts/generate_openapi.sh
 
-      - uses: EndBug/add-and-commit@v9 # You can change this to use a specific version.
+      - name: Open Pull Request
+        uses: peter-evans/create-pull-request@v6
         with:
-          author_name: "github-actions[bot]"
-          author_email: "github-actions[bot]@users.noreply.github.com"
-          message: "chore: update split specs and generated Go OpenAPI client"
+          # GH_TOKEN (not the default GITHUB_TOKEN) so CI workflows
+          # trigger on the auto-opened PR. GITHUB_TOKEN-opened PRs are
+          # blocked by GitHub's anti-loop protection.
+          token: ${{ secrets.GH_TOKEN }}
+          base: master
+          branch: auto/facade-sync-${{ steps.facade.outputs.short_sha }}
+          delete-branch: true
+          add-paths: |
+            openapi.yaml
+            specs/**
+            go/openapi/gen/**
+          commit-message: "chore: sync OpenAPI SDK from openapi-facade ${{ steps.facade.outputs.short_sha }}"
+          title: "Sync OpenAPI SDK from openapi-facade ${{ steps.facade.outputs.short_sha }}"
+          body: |
+            Automated sync of OpenAPI clients from `${{ env.FACADE_REPO }}` `${{ env.FACADE_SPEC_PATH }}`.
+
+            Jira: [CX-42158](https://coralogix.atlassian.net/browse/CX-42158) (umbrella ticket for automated OpenAPI SDK syncs)
+
+            Source commit: [`${{ steps.facade.outputs.short_sha }}`](https://github.com/${{ env.FACADE_REPO }}/commit/${{ steps.facade.outputs.sha }})
+
+            Regenerated:
+            - `openapi.yaml`
+            - `specs/**` (via `tools/openapi-split`)
+            - `go/openapi/gen/**` (via `go/scripts/generate_openapi.sh`)
+          labels: |
+            sync
+            facade-sync

--- a/.github/workflows/sync-latest-spec.yaml
+++ b/.github/workflows/sync-latest-spec.yaml
@@ -1,12 +1,5 @@
-name: Generate OpenAPI Clients
+name: Sync and Generate OpenAPI SDK
 
-# TODO: rename file to sync-latest-spec.yaml and workflow to
-# "Sync and Generate OpenAPI SDK" once this branch has been verified
-# end-to-end. Filename is kept the same as on master so the new
-# workflow_dispatch path is discoverable when triggering from this
-# branch (workflow_dispatch only fires from files that exist on the
-# default branch at the same path).
-#
 # Triggered by openapi-facade's notify-spec-consumers.yml workflow
 # (event_type: facade-spec-updated) whenever may26/openapi.yaml changes
 # on master, or manually via workflow_dispatch. Fetches the spec from

--- a/tools/openapi-split/split_specs.sh
+++ b/tools/openapi-split/split_specs.sh
@@ -24,15 +24,16 @@ fi
 echo "Starting batch processing for files in '$SPEC_DIR/'..."
 echo "--------------------------------------------------------"
 
-for file in "$SPEC_DIR"/*; do
-    if [ -f "$file" ]; then
-        echo "--> Found file: $file"
-        npx @redocly/cli@latest bundle "$file" --output "$file" --remove-unused-components &
-    fi
-done
+# Use the globally-installed `redocly` binary (assumed on PATH; CI does
+# `npm install -g @redocly/cli@latest`) instead of `npx @redocly/cli@latest`.
+# Bundling files in parallel via `npx` corrupts its shared npm cache and
+# OOMs the runner with 46+ concurrent processes. Limit to 4 concurrent
+# bundles via `xargs -P 4`.
+find "$SPEC_DIR" -maxdepth 1 -type f -print0 \
+    | xargs -0 -n 1 -P 4 -I {} \
+        redocly bundle {} --output {} --remove-unused-components
 
 echo "--------------------------------------------------------"
-wait $(jobs -p)
 echo "Batch processing complete."
 
 # Remove existing specs directory if it exists


### PR DESCRIPTION
## Summary

Rewrites `.github/workflows/openapi-generate-clients.yml` so the SDK regenerates automatically from `coralogix/openapi-facade` `may26/openapi.yaml`.

**Filename kept the same on purpose** — `workflow_dispatch` only fires from files that already exist on the default branch at the matching path, so keeping the existing filename means I can trigger the new flow from this branch with `gh workflow run openapi-generate-clients.yml --ref CX-40734-openapi-facade-auto-sync` before merging. The file and workflow will be renamed to `sync-latest-spec.yaml` / `Sync and Generate OpenAPI SDK` in a follow-up PR once this is verified end-to-end (TODO comment in the file).

**Triggers:**
- `repository_dispatch` (event type `facade-spec-updated`) — fired by `openapi-facade`'s `notify-spec-consumers.yml` whenever `may26/openapi.yaml` changes on master.
- `workflow_dispatch` — manual trigger with optional `facade_ref` input; defaults to facade `master` HEAD.

**Removed from the previous version:** `specDownloadUrl` input, `curl` step, `pull_request` trigger, `EndBug/add-and-commit` step. Facade is now the single source of truth.

**Flow:**
1. Resolve facade commit SHA (from dispatch payload, manual input, or facade master HEAD).
2. Fetch `may26/openapi.yaml` via `gh api` with `Accept: application/vnd.github.raw` (the spec is >1MB; the contents API returns base64-empty above 1MB).
3. Run `tools/openapi-split/split_specs.sh` (rewrites `specs/`).
4. Run `go/scripts/generate_openapi.sh` (rewrites `go/openapi/gen/`).
5. Open a PR to `master` on branch `auto/facade-sync-<short-sha>` via `peter-evans/create-pull-request@v6`, labels `sync` + `facade-sync`.

## Required to complete the wiring

Dispatcher side: https://github.com/coralogix/openapi-facade/pull/274 (draft) — adds a second `peter-evans/repository-dispatch@v3` step targeting this repo and renames the workflow to `notify-spec-consumers.yml`.

Verify the `GH_TOKEN` secret in `openapi-facade` has `contents: write` (fine-grained) or `repo` (classic) scope on this repo — if not, add a new `SDK_DISPATCH_TOKEN` secret for the second dispatch step.

## Test plan

- [ ] Trigger from this branch: `gh workflow run openapi-generate-clients.yml --ref CX-40734-openapi-facade-auto-sync` → confirm a PR titled `Sync OpenAPI SDK from openapi-facade <sha>` appears with regenerated `openapi.yaml`, `specs/**`, and `go/openapi/gen/**`.
- [ ] Trigger with explicit facade SHA: `gh workflow run openapi-generate-clients.yml --ref CX-40734-openapi-facade-auto-sync -F facade_ref=<some-sha>` → confirm the resolved SHA in the PR body matches.
- [ ] Once the facade-side PR ships, push a no-op change to `may26/openapi.yaml` on `openapi-facade` master → confirm an `auto/facade-sync-<sha>` PR appears here within ~2 min, and that `go-code-check.yml` runs against it.
- [ ] Follow-up: rename file to `sync-latest-spec.yaml` and workflow `name:` to `Sync and Generate OpenAPI SDK` once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)