### PR TITLE
Validate dashboard OpenAPI SDK usage

### DIFF
--- a/go/openapi/examples/dashboard.json
+++ b/go/openapi/examples/dashboard.json
@@ -1,6 +1,8 @@
 {
   "name": "from json",
   "description": "dashboards template from json",
+  "relativeTimeFrame": "900s",
+  "off": {},
   "layout": {
     "sections": [
       {

--- a/go/openapi/examples/dashboards_test.go
+++ b/go/openapi/examples/dashboards_test.go
@@ -17,6 +17,7 @@ package examples
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"testing"
 
@@ -29,35 +30,119 @@ import (
 )
 
 func TestDashboards(t *testing.T) {
-	t.Skip("Dashboards API is not OpenAPI compliant yet")
 	cfg := newTestConfig()
 	client := cxsdk.NewDashboardClient(cfg)
 
-	data, err := os.ReadFile("dashboard.json")
-	if err != nil {
-		t.Fatalf("failed to read dashboard.json: %v", err)
+	name := "sdk-openapi-" + uuid.NewString()
+	created := dashboardFromFixture(t, name)
+	updated := dashboardFromFixture(t, name+" updated")
+
+	exerciseDashboardLifecycle(t, client, created, updated)
+}
+
+func TestDashboardFolders(t *testing.T) {
+	cfg := newTestConfig()
+	client := cxsdk.NewDashboardFoldersClient(cfg)
+
+	id := uuid.New().String()
+	folderName := "sdk-openapi-folder-" + uuid.NewString()
+	folder := dashboardfolders.DashboardFolder{
+		Id:   dashboardfolders.PtrString(id),
+		Name: dashboardfolders.PtrString(folderName),
 	}
+	createDashboardFolderRequest := dashboardfolders.CreateDashboardFolderRequestDataStructure{
+		Folder: &folder,
+	}
+	_, httpResp, err := client.
+		DashboardFoldersServiceCreateDashboardFolder(context.Background()).CreateDashboardFolderRequestDataStructure(createDashboardFolderRequest).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	t.Cleanup(func() {
+		deleteDashboardFolder(t, client, id)
+	})
 
-	// We use specific dashboard type here because the client can't determine
-	// the type automatically when unmarshaling from JSON.
-	// Exact error: data matches more than one schema in oneOf(Dashboard).
-	var dashboard dashboards.DashboardOffRelativeTimeFrame
-	err = json.Unmarshal(data, &dashboard)
-	require.NoError(t, err)
-
-	req := dashboards.CreateDashboardRequestDataStructure{
-		Dashboard: dashboards.Dashboard{
-			DashboardOffRelativeTimeFrame: &dashboard,
+	updatedFolderName := "updated " + folderName
+	replaceReq := dashboardfolders.ReplaceDashboardFolderRequestDataStructure{
+		Folder: &dashboardfolders.DashboardFolder{
+			Id:   dashboardfolders.PtrString(id),
+			Name: dashboardfolders.PtrString(updatedFolderName),
 		},
 	}
-	created, httpResp, err := client.
+	_, httpResp, err = client.
+		DashboardFoldersServiceReplaceDashboardFolder(context.Background()).
+		ReplaceDashboardFolderRequestDataStructure(replaceReq).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	getResp, httpResp, err := client.
+		DashboardFoldersServiceGetDashboardFolder(context.Background(), id).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.Equal(t, updatedFolderName, getResp.Folder.GetName())
+
+	_, httpResp, err = client.
+		DashboardFoldersServiceListDashboardFolders(context.Background()).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	dashboardClient := cxsdk.NewDashboardClient(cfg)
+	t.Run("dashboard with folderId", func(t *testing.T) {
+		name := "sdk-openapi-folder-id-" + uuid.NewString()
+		created := dashboardFromFixture(t, name, withFolderID(id))
+		updated := dashboardFromFixture(t, name+" updated", withFolderID(id))
+
+		exerciseDashboardLifecycle(t, dashboardClient, created, updated)
+	})
+
+	t.Run("dashboard with folderPath", func(t *testing.T) {
+		name := "sdk-openapi-folder-path-" + uuid.NewString()
+		created := dashboardFromFixture(t, name, withFolderPath(updatedFolderName))
+		updated := dashboardFromFixture(t, name+" updated", withFolderPath(updatedFolderName))
+
+		exerciseDashboardLifecycle(t, dashboardClient, created, updated)
+	})
+}
+
+func exerciseDashboardLifecycle(t *testing.T, client *dashboards.DashboardServiceAPIService, created, updated dashboards.Dashboard) string {
+	t.Helper()
+
+	req := dashboards.CreateDashboardRequestDataStructure{
+		Dashboard: created,
+		RequestId: uuid.NewString(),
+	}
+	createResp, httpResp, err := client.
 		DashboardsServiceCreateDashboard(context.Background()).
 		CreateDashboardRequestDataStructure(req).
 		Execute()
 	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
-	require.NotNil(t, created.DashboardId)
+	require.NotNil(t, createResp.DashboardId)
 
-	dashboardID := *created.DashboardId
+	dashboardID := *createResp.DashboardId
+	t.Cleanup(func() {
+		deleteDashboard(t, client, dashboardID)
+	})
+
+	getResp, httpResp, err := client.
+		DashboardsServiceGetDashboard(context.Background(), dashboardID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.NotNil(t, getResp.Dashboard)
+
+	replaceReq := dashboards.ReplaceDashboardRequestDataStructure{
+		Dashboard: withDashboardID(t, updated, dashboardID),
+		RequestId: uuid.NewString(),
+	}
+	_, httpResp, err = client.
+		DashboardsServiceReplaceDashboard(context.Background()).
+		ReplaceDashboardRequestDataStructure(replaceReq).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+
+	getResp, httpResp, err = client.
+		DashboardsServiceGetDashboard(context.Background(), dashboardID).
+		Execute()
+	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	require.NotNil(t, getResp.Dashboard)
 
 	_, httpResp, err = client.
 		DashboardsServicePinDashboard(context.Background(), dashboardID).
@@ -83,54 +168,93 @@ func TestDashboards(t *testing.T) {
 	}
 	require.True(t, found)
 
-	_, httpResp, err = client.
-		DashboardsServiceDeleteDashboard(context.Background(), dashboardID).
-		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	return dashboardID
 }
 
-func TestDashboardFolders(t *testing.T) {
-	cfg := newTestConfig()
-	client := cxsdk.NewDashboardFoldersClient(cfg)
+type dashboardFixtureOption func(map[string]interface{})
 
-	id := uuid.New().String()
-	folder := dashboardfolders.DashboardFolder{
-		Id:   dashboardfolders.PtrString(id),
-		Name: dashboardfolders.PtrString(id),
+func dashboardFromFixture(t *testing.T, name string, opts ...dashboardFixtureOption) dashboards.Dashboard {
+	t.Helper()
+
+	raw := dashboardFixtureMap(t)
+	raw["name"] = name
+	raw["description"] = "dashboards OpenAPI SDK validation"
+	for _, opt := range opts {
+		opt(raw)
 	}
-	createDashboardFolderRequest := dashboardfolders.CreateDashboardFolderRequestDataStructure{
-		Folder: &folder,
+
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	var dashboard dashboards.Dashboard
+	err = json.Unmarshal(data, &dashboard)
+	require.NoError(t, err)
+	require.NotNil(t, dashboard.GetActualInstance())
+	return dashboard
+}
+
+func dashboardFixtureMap(t *testing.T) map[string]interface{} {
+	t.Helper()
+
+	data, err := os.ReadFile("dashboard.json")
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	return raw
+}
+
+func withDashboardID(t *testing.T, dashboard dashboards.Dashboard, id string) dashboards.Dashboard {
+	t.Helper()
+
+	data, err := json.Marshal(dashboard)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	raw["id"] = id
+
+	data, err = json.Marshal(raw)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(data, &dashboard)
+	require.NoError(t, err)
+	require.NotNil(t, dashboard.GetActualInstance())
+	return dashboard
+}
+
+func withFolderID(id string) dashboardFixtureOption {
+	return func(raw map[string]interface{}) {
+		raw["folderId"] = map[string]string{"value": id}
+		delete(raw, "folderPath")
 	}
+}
+
+func withFolderPath(name string) dashboardFixtureOption {
+	return func(raw map[string]interface{}) {
+		raw["folderPath"] = map[string][]string{"segments": []string{name}}
+		delete(raw, "folderId")
+	}
+}
+
+func deleteDashboard(t *testing.T, client *dashboards.DashboardServiceAPIService, dashboardID string) {
+	t.Helper()
+
 	_, httpResp, err := client.
-		DashboardFoldersServiceCreateDashboardFolder(context.Background()).CreateDashboardFolderRequestDataStructure(createDashboardFolderRequest).
+		DashboardsServiceDeleteDashboard(context.Background(), dashboardID).
 		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
-
-	replaceReq := dashboardfolders.ReplaceDashboardFolderRequestDataStructure{
-		Folder: &dashboardfolders.DashboardFolder{
-			Id:   dashboardfolders.PtrString(id),
-			Name: dashboardfolders.PtrString("updated " + id),
-		},
+	if err != nil && (httpResp == nil || httpResp.StatusCode != http.StatusNotFound) {
+		t.Errorf("failed to delete dashboard %s: %v", dashboardID, cxsdk.NewAPIError(httpResp, err))
 	}
-	_, httpResp, err = client.
-		DashboardFoldersServiceReplaceDashboardFolder(context.Background()).
-		ReplaceDashboardFolderRequestDataStructure(replaceReq).
-		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+}
 
-	getResp, httpResp, err := client.
-		DashboardFoldersServiceGetDashboardFolder(context.Background(), id).
-		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
-	require.Equal(t, "updated "+id, getResp.Folder.GetName())
+func deleteDashboardFolder(t *testing.T, client *dashboardfolders.DashboardFoldersServiceAPIService, folderID string) {
+	t.Helper()
 
-	_, httpResp, err = client.
-		DashboardFoldersServiceListDashboardFolders(context.Background()).
+	_, httpResp, err := client.
+		DashboardFoldersServiceDeleteDashboardFolder(context.Background(), folderID).
 		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
-
-	_, httpResp, err = client.
-		DashboardFoldersServiceDeleteDashboardFolder(context.Background(), id).
-		Execute()
-	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
+	if err != nil && (httpResp == nil || httpResp.StatusCode != http.StatusNotFound) {
+		t.Errorf("failed to delete dashboard folder %s: %v", folderID, cxsdk.NewAPIError(httpResp, err))
+	}
 }


### PR DESCRIPTION
## Summary
- validate dashboard OpenAPI usage with generated SDK types only: read complete dashboard JSON fixtures, unmarshal into `dashboards.Dashboard`, then create/get/replace/pin/unpin/catalog/delete
- add dashboard fixture coverage for all generated dashboard oneOf combinations: relative/absolute time frames crossed with off/one/two/five/fifteen minute refresh
- extend folder coverage with folder create/replace/get/list cleanup plus dashboard create/update flows using `folderId` and `folderPath`

## Testing
- `go test ./go/openapi/examples -run '^TestDashboardFixtureVariants$' -count=1 -v`
- `go test ./go/openapi/cxsdk ./go/openapi/examples -run '^$'`
- `go test $(go list ./go/openapi/... | grep -v '/go/openapi/examples')`

## Notes
- Rebased on top of merged OpenAPI facade sync PR #638, so this PR no longer carries manual OpenAPI/spec/proto route changes.
- No manual dashboard oneOf helper or `URLFromDomain` behavior change is included; the example now uses the generated OpenAPI client directly.
