### PR TITLE
normalize regex of over escaped \s and \S

### DIFF
--- a/go/openapi/examples/ai_test.go
+++ b/go/openapi/examples/ai_test.go
@@ -16,6 +16,7 @@ package examples
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -279,6 +280,51 @@ func TestAICustomEvaluations(t *testing.T) {
 		Execute()
 	require.NoError(t, cxsdk.NewAPIError(httpResp, err))
 	require.False(t, customEvaluationExists(customEvaluations.GetItems(), customEvaluationID))
+}
+
+func TestAIEvaluationConfigDecodesPromptInjection(t *testing.T) {
+	payload := []byte(`{
+		"promptInjection": {
+			"additionalContext": "Only inspect the user prompt."
+		}
+	}`)
+
+	var config aievaluations.EvaluationConfig
+	require.NoError(t, json.Unmarshal(payload, &config))
+
+	promptInjection, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigPromptInjection)
+	require.Truef(t, ok, "expected promptInjection config, got %T", config.GetActualInstance())
+	promptInjectionConfig, ok := promptInjection.GetPromptInjectionOk()
+	require.True(t, ok)
+	require.Equal(t, "Only inspect the user prompt.", promptInjectionConfig.GetAdditionalContext())
+}
+
+func TestAIEvaluationConfigDecodesCustomEvaluation(t *testing.T) {
+	payload := []byte(`{
+		"customEvaluation": {
+			"instructions": "Score 1 when the response mentions a competitor.\nScore 0 otherwise.",
+			"policyType": "competition",
+			"safe": "does not mention competitors",
+			"violates": "mentions a competitor product",
+			"shouldIncludeSystemPrompt": false,
+			"examples": [
+				{
+					"conversation": "User: which tool is best?\nAssistant: CompetitorX is great.",
+					"score": "1"
+				}
+			]
+		}
+	}`)
+
+	var config aievaluations.EvaluationConfig
+	require.NoError(t, json.Unmarshal(payload, &config))
+
+	customEvaluation, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigCustomEvaluation)
+	require.Truef(t, ok, "expected customEvaluation config, got %T", config.GetActualInstance())
+	customEvaluationConfig, ok := customEvaluation.GetCustomEvaluationOk()
+	require.True(t, ok)
+	require.Equal(t, "competition", customEvaluationConfig.GetPolicyType())
+	require.Len(t, customEvaluationConfig.GetExamples(), 1)
 }
 
 func deleteAIEvaluation(t *testing.T, client *aievaluations.AIEvaluationsServiceAPIService, id string) {

--- a/go/openapi/gen/ai_applications_service/model_ai_application.go
+++ b/go/openapi/gen/ai_applications_service/model_ai_application.go
@@ -24,9 +24,9 @@ var _ MappedNullable = &AiApplication{}
 // AiApplication AI Application
 type AiApplication struct {
 	// Application name.
-	Application *string `json:"application,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Application *string `json:"application,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Company ID
-	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// RFC3339 timestamp when the application was first observed.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 	// Whether guardrails are integrated for this application.
@@ -34,7 +34,7 @@ type AiApplication struct {
 	// Unique identifier of the AI application.
 	Id *string `json:"id,omitempty" validate:"regexp=^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"`
 	// Subsystem name
-	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// RFC3339 timestamp when the application was last updated.
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/ai_applications_service/model_company_model_pricing.go
+++ b/go/openapi/gen/ai_applications_service/model_company_model_pricing.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &CompanyModelPricing{}
 // CompanyModelPricing Company-wide custom model pricing configuration.
 type CompanyModelPricing struct {
 	// Company identifier.
-	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Unique identifier of the pricing record.
 	Id *string `json:"id,omitempty" validate:"regexp=^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"`
 	// Map of model name to custom price. Replaces all existing prices on set.

--- a/go/openapi/gen/ai_evaluations_service/model_ai_evaluation.go
+++ b/go/openapi/gen/ai_evaluations_service/model_ai_evaluation.go
@@ -24,9 +24,9 @@ var _ MappedNullable = &AiEvaluation{}
 // AiEvaluation A configured AI evaluation that runs against an AI application's spans.
 type AiEvaluation struct {
 	// Name of the AI application this evaluation belongs to.
-	Application *string `json:"application,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Application *string `json:"application,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Company that owns this evaluation.
-	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	CompanyId *string `json:"companyId,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Config *EvaluationConfig `json:"config,omitempty"`
 	// RFC3339 timestamp when the evaluation was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
@@ -37,7 +37,7 @@ type AiEvaluation struct {
 	// Whether the evaluation is currently active.
 	IsEnabled *bool `json:"isEnabled,omitempty"`
 	// Subsystem within the application.
-	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Target *EvaluationTarget `json:"target,omitempty"`
 	// Score threshold. Must be between 0.0 and 1.0 inclusive.
 	Threshold *float64 `json:"threshold,omitempty"`

--- a/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_create_ai_evaluation_request.go
+++ b/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_create_ai_evaluation_request.go
@@ -23,12 +23,12 @@ var _ MappedNullable = &AiEvaluationsServiceCreateAiEvaluationRequest{}
 // AiEvaluationsServiceCreateAiEvaluationRequest Request to create a new AI evaluation.
 type AiEvaluationsServiceCreateAiEvaluationRequest struct {
 	// Name of the AI application this evaluation belongs to.
-	Application *string `json:"application,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Application *string `json:"application,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Config *EvaluationConfig `json:"config,omitempty"`
 	// Whether the evaluation should start active.
 	IsEnabled *bool `json:"isEnabled,omitempty"`
 	// Subsystem within the application.
-	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Target *EvaluationTarget `json:"target,omitempty"`
 	// Score threshold. Must be between 0.0 and 1.0 inclusive.
 	Threshold *float64 `json:"threshold,omitempty"`

--- a/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_create_custom_evaluation_request.go
+++ b/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_create_custom_evaluation_request.go
@@ -25,21 +25,21 @@ type AiEvaluationsServiceCreateCustomEvaluationRequest struct {
 	// IDs of AI applications to link this custom evaluation to.
 	ApplicationIds []string `json:"applicationIds,omitempty"`
 	// Human-readable description.
-	Description *string `json:"description,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Description *string `json:"description,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Example conversations and expected scores.
 	Examples []CustomEvaluationExample `json:"examples,omitempty"`
 	// Instructions sent to the LLM evaluator.
-	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Display name of the custom evaluation.
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Policy type identifier.
-	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Description of what counts as safe.
-	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Whether to include the system prompt in the LLM input.
 	ShouldIncludeSystemPrompt *bool `json:"shouldIncludeSystemPrompt,omitempty"`
 	// Description of what counts as violating the policy.
-	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_update_ai_evaluation_request.go
+++ b/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_update_ai_evaluation_request.go
@@ -23,12 +23,12 @@ var _ MappedNullable = &AiEvaluationsServiceUpdateAiEvaluationRequest{}
 // AiEvaluationsServiceUpdateAiEvaluationRequest Request to update an existing AI evaluation.
 type AiEvaluationsServiceUpdateAiEvaluationRequest struct {
 	// Name of the AI application this evaluation belongs to.
-	Application *string `json:"application,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Application *string `json:"application,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Config *EvaluationConfig `json:"config,omitempty"`
 	// Whether the evaluation is active.
 	IsEnabled *bool `json:"isEnabled,omitempty"`
 	// Subsystem within the application.
-	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Subsystem *string `json:"subsystem,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	Target *EvaluationTarget `json:"target,omitempty"`
 	// Score threshold. Must be between 0.0 and 1.0 inclusive.
 	Threshold *float64 `json:"threshold,omitempty"`

--- a/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_update_custom_evaluation_request.go
+++ b/go/openapi/gen/ai_evaluations_service/model_ai_evaluations_service_update_custom_evaluation_request.go
@@ -23,23 +23,23 @@ var _ MappedNullable = &AiEvaluationsServiceUpdateCustomEvaluationRequest{}
 // AiEvaluationsServiceUpdateCustomEvaluationRequest Request to update a custom evaluation in the catalog.
 type AiEvaluationsServiceUpdateCustomEvaluationRequest struct {
 	// Human-readable description.
-	Description *string `json:"description,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Description *string `json:"description,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Example conversations and expected scores.
 	Examples []CustomEvaluationExample `json:"examples,omitempty"`
 	// Instructions sent to the LLM evaluator.
-	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Display name of the custom evaluation.
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Policy type identifier.
-	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Description of what counts as safe.
-	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Whether to include the system prompt in the LLM input.
 	ShouldIncludeSystemPrompt *bool `json:"shouldIncludeSystemPrompt,omitempty"`
 	// Comma-separated list of field paths to update. When provided, only the listed fields are touched; a listed field that is absent from the request body is cleared. When omitted, only fields present in the body are updated.
 	UpdateMask *string `json:"updateMask,omitempty" validate:"regexp=^[a-zA-Z_][a-zA-Z0-9_]*(,[a-zA-Z_][a-zA-Z0-9_]*)*$"`
 	// Description of what counts as violating the policy.
-	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/ai_evaluations_service/model_custom_evaluation.go
+++ b/go/openapi/gen/ai_evaluations_service/model_custom_evaluation.go
@@ -26,11 +26,11 @@ type CustomEvaluation struct {
 	ApplicationIds []string `json:"applicationIds,omitempty"`
 	Config *CustomEvaluationConfig `json:"config,omitempty"`
 	// Human-readable description.
-	Description *string `json:"description,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Description *string `json:"description,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Unique identifier of the custom evaluation.
 	Id *string `json:"id,omitempty" validate:"regexp=^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"`
 	// Display name of the custom evaluation.
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/ai_evaluations_service/model_custom_evaluation_config.go
+++ b/go/openapi/gen/ai_evaluations_service/model_custom_evaluation_config.go
@@ -25,15 +25,15 @@ type CustomEvaluationConfig struct {
 	// Example conversations and expected scores.
 	Examples []CustomEvaluationExample `json:"examples,omitempty"`
 	// Instructions sent to the LLM evaluator.
-	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	Instructions *string `json:"instructions,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Policy type identifier.
-	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\\\s\\\\S]+$"`
+	PolicyType *string `json:"policyType,omitempty" validate:"regexp=^[\\s\\S]+$"`
 	// Description of what counts as safe.
-	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Safe *string `json:"safe,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Whether to include the system prompt in the LLM input.
 	ShouldIncludeSystemPrompt *bool `json:"shouldIncludeSystemPrompt,omitempty"`
 	// Description of what counts as violating the policy.
-	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Violates *string `json:"violates,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/ai_evaluations_service/model_custom_evaluation_example.go
+++ b/go/openapi/gen/ai_evaluations_service/model_custom_evaluation_example.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &CustomEvaluationExample{}
 // CustomEvaluationExample A single labeled example for a custom evaluation.
 type CustomEvaluationExample struct {
 	// Example conversation text.
-	Conversation *string `json:"conversation,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Conversation *string `json:"conversation,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Expected score for this example.
 	Score *string `json:"score,omitempty" validate:"regexp=^[0-9]+$"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/ai_evaluations_service/model_prompt_injection_config.go
+++ b/go/openapi/gen/ai_evaluations_service/model_prompt_injection_config.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &PromptInjectionConfig{}
 // PromptInjectionConfig Configuration for the PromptInjection evaluation.
 type PromptInjectionConfig struct {
 	// Additional context passed to the LLM evaluator.
-	AdditionalContext *string `json:"additionalContext,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AdditionalContext *string `json:"additionalContext,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/alert_definitions_service/model_analytics_threshold_type.go
+++ b/go/openapi/gen/alert_definitions_service/model_analytics_threshold_type.go
@@ -30,7 +30,7 @@ type AnalyticsThresholdType struct {
 	// The per-priority threshold rules
 	Rules []AnalyticsThresholdRule `json:"rules,omitempty"`
 	// The name of the numeric result column to compare
-	TargetColumn *string `json:"targetColumn,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	TargetColumn *string `json:"targetColumn,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// The evaluation window duration in minutes
 	TimeframeMinutes *int32 `json:"timeframeMinutes,omitempty"`
 	// Whether each result row is treated as a separate permutation. Defaults to true for threshold alerts as permutation count is easier to estimate.

--- a/go/openapi/gen/alert_definitions_service/model_dataprime_alert_query.go
+++ b/go/openapi/gen/alert_definitions_service/model_dataprime_alert_query.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &DataprimeAlertQuery{}
 // DataprimeAlertQuery A DataPrime query
 type DataprimeAlertQuery struct {
 	// The DataPrime query string
-	Query *string `json:"query,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Query *string `json:"query,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/case_events_service/model_pager_duty_actor.go
+++ b/go/openapi/gen/case_events_service/model_pager_duty_actor.go
@@ -25,11 +25,11 @@ type PagerDutyActor struct {
 	// If the PagerDuty user is linked to a Coralogix user, this field contains the Coralogix user ID.
 	CoralogixUserId *string `json:"coralogixUserId,omitempty" validate:"regexp=^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"`
 	// PagerDuty display name
-	DisplayName *string `json:"displayName,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	DisplayName *string `json:"displayName,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// PagerDuty user ID
-	PagerDutyUserId *string `json:"pagerDutyUserId,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	PagerDutyUserId *string `json:"pagerDutyUserId,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Email of the PagerDuty user
-	UserEmail *string `json:"userEmail,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	UserEmail *string `json:"userEmail,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/case_events_service/model_prometheus_alert_manager_actor.go
+++ b/go/openapi/gen/case_events_service/model_prometheus_alert_manager_actor.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &PrometheusAlertManagerActor{}
 // PrometheusAlertManagerActor Information about the Prometheus Alert Manager instance that initiated the action.
 type PrometheusAlertManagerActor struct {
 	// Prometheus Alert Manager receiver name
-	ReceiverName *string `json:"receiverName,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	ReceiverName *string `json:"receiverName,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/case_settings_service/model_case_settings.go
+++ b/go/openapi/gen/case_settings_service/model_case_settings.go
@@ -30,7 +30,7 @@ type CaseSettings struct {
 	// Unique identifier for the team configuration
 	Id *string `json:"id,omitempty" validate:"regexp=^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"`
 	// Human-readable name for the team configuration
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Timestamp when the team configuration was last updated
 	UpdateTime *time.Time `json:"updateTime,omitempty"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/case_settings_service/model_create_case_settings_request.go
+++ b/go/openapi/gen/case_settings_service/model_create_case_settings_request.go
@@ -26,7 +26,7 @@ type CreateCaseSettingsRequest struct {
 	CaseLifecycle *CaseLifecycle `json:"caseLifecycle,omitempty"`
 	GlobalIndicatorSettings GlobalIndicatorSettings `json:"globalIndicatorSettings"`
 	// Optional display name for the case settings team configuration
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/case_settings_service/model_update_case_settings_request.go
+++ b/go/openapi/gen/case_settings_service/model_update_case_settings_request.go
@@ -25,7 +25,7 @@ type UpdateCaseSettingsRequest struct {
 	CaseLifecycle *CaseLifecycle `json:"caseLifecycle,omitempty"`
 	GlobalIndicatorSettings *GlobalIndicatorSettings `json:"globalIndicatorSettings,omitempty"`
 	// New display name for the case settings team configuration
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_alert_indicator.go
+++ b/go/openapi/gen/cases_service/model_alert_indicator.go
@@ -30,7 +30,7 @@ type AlertIndicator struct {
 	AlertVersions []string `json:"alertVersions"`
 	GroupingType AlertGroupingType `json:"groupingType"`
 	// Last seen version ID of the triggered alert definition.
-	LatestAlertVersion string `json:"latestAlertVersion" validate:"regexp=^[\\\\s\\\\S]*$"`
+	LatestAlertVersion string `json:"latestAlertVersion" validate:"regexp=^[\\s\\S]*$"`
 	// Array of the alert permutations.
 	Permutations []AlertIndicatorPermutation `json:"permutations"`
 	Priority IndicatorPriority `json:"priority"`

--- a/go/openapi/gen/cases_service/model_apm_database_entity.go
+++ b/go/openapi/gen/cases_service/model_apm_database_entity.go
@@ -23,9 +23,9 @@ var _ MappedNullable = &ApmDatabaseEntity{}
 // ApmDatabaseEntity Application Performance Monitoring database identified as impacted by a case.
 type ApmDatabaseEntity struct {
 	// Name of the impacted database
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Database system (e.g., postgresql, mysql)
-	System *string `json:"system,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	System *string `json:"system,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_apm_service_entity.go
+++ b/go/openapi/gen/cases_service/model_apm_service_entity.go
@@ -23,9 +23,9 @@ var _ MappedNullable = &ApmServiceEntity{}
 // ApmServiceEntity Application Performance Monitoring service identified as impacted by a case.
 type ApmServiceEntity struct {
 	// Programming language of the APM service
-	Language *string `json:"language,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Language *string `json:"language,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Name of the impacted APM service
-	Name *string `json:"name,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Name *string `json:"name,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_assignee_count.go
+++ b/go/openapi/gen/cases_service/model_assignee_count.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &AssigneeCount{}
 // AssigneeCount Count of cases for a single assignee.
 type AssigneeCount struct {
 	// Identifier of the assignee
-	Assignee *string `json:"assignee,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Assignee *string `json:"assignee,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Number of cases assigned to this assignee
 	Count *int64 `json:"count,omitempty"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_assignee_option_assignee.go
+++ b/go/openapi/gen/cases_service/model_assignee_option_assignee.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &AssigneeOptionAssignee{}
 // AssigneeOptionAssignee Assignee filter option representing either a specific assignee or unassigned cases.
 type AssigneeOptionAssignee struct {
 	// User identifier of the assignee to filter by
-	Assignee string `json:"assignee" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Assignee string `json:"assignee" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_bulk_resolve_request.go
+++ b/go/openapi/gen/cases_service/model_bulk_resolve_request.go
@@ -26,7 +26,7 @@ type BulkResolveRequest struct {
 	// IDs of the cases to resolve. Each entry accepts either the case UUID (the `id` field on a case) or the readable identifier (the `readable_id` field, e.g. `CASE-123`).
 	Ids []string `json:"ids"`
 	// Reason for resolution
-	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_case.go
+++ b/go/openapi/gen/cases_service/model_case.go
@@ -27,7 +27,7 @@ type Case struct {
 	// When the case was acknowledged
 	AcknowledgeTime *time.Time `json:"acknowledgeTime,omitempty"`
 	// AI summary of the case
-	AiSummary *string `json:"aiSummary,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AiSummary *string `json:"aiSummary,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	Assignee *CasesV1UserDetails `json:"assignee,omitempty"`
 	CaseIndicators *CaseIndicators `json:"caseIndicators,omitempty"`
 	Category CaseCategory `json:"category"`
@@ -52,7 +52,7 @@ type Case struct {
 	ResolutionDetails *ResolutionDetails `json:"resolutionDetails,omitempty"`
 	Status CaseStatus `json:"status"`
 	// Case title
-	Title string `json:"title" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Title string `json:"title" validate:"regexp=^[\\s\\S]*$"`
 	// When the case was last updated
 	UpdateTime *time.Time `json:"updateTime,omitempty"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_case_filters.go
+++ b/go/openapi/gen/cases_service/model_case_filters.go
@@ -44,7 +44,7 @@ type CaseFilters struct {
 	// List of case statuses to filter on
 	Statuses []CaseStatus `json:"statuses,omitempty"`
 	// Test search query applied to case titles
-	TextSearch *string `json:"textSearch,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	TextSearch *string `json:"textSearch,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_case_patch.go
+++ b/go/openapi/gen/cases_service/model_case_patch.go
@@ -23,9 +23,9 @@ var _ MappedNullable = &CasePatch{}
 // CasePatch Partial set of fields to update on the case
 type CasePatch struct {
 	// New case resolution reason
-	ResolutionReason *string `json:"resolutionReason,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	ResolutionReason *string `json:"resolutionReason,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// New case title
-	Title *string `json:"title,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Title *string `json:"title,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_cases_v1_pagination_request.go
+++ b/go/openapi/gen/cases_service/model_cases_v1_pagination_request.go
@@ -25,7 +25,7 @@ type CasesV1PaginationRequest struct {
 	// Number of items to return per page
 	PageSize *int64 `json:"pageSize,omitempty"`
 	// Token for the next page of results
-	PageToken *string `json:"pageToken,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	PageToken *string `json:"pageToken,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Number of items to skip before starting to collect results
 	Skip *int64 `json:"skip,omitempty"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_cases_v1_pagination_response.go
+++ b/go/openapi/gen/cases_service/model_cases_v1_pagination_response.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &CasesV1PaginationResponse{}
 // CasesV1PaginationResponse Pagination information for list responses.
 type CasesV1PaginationResponse struct {
 	// Token for the next page of results
-	NextPageToken *string `json:"nextPageToken,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	NextPageToken *string `json:"nextPageToken,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_entity_link.go
+++ b/go/openapi/gen/cases_service/model_entity_link.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &EntityLink{}
 // EntityLink A URL reference to an entity in the originating system.
 type EntityLink struct {
 	// URL to the entity in the originating system.
-	Url string `json:"url" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Url string `json:"url" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_filter_group.go
+++ b/go/openapi/gen/cases_service/model_filter_group.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &FilterGroup{}
 // FilterGroup A filter group containing a key and its possible values.
 type FilterGroup struct {
 	// Key of the filter group (e.g., service, environment)
-	Key string `json:"key" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Key string `json:"key" validate:"regexp=^[\\s\\S]*$"`
 	// Values associated with the filter group key
 	Values []string `json:"values"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_filter_group_aggregation.go
+++ b/go/openapi/gen/cases_service/model_filter_group_aggregation.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &FilterGroupAggregation{}
 // FilterGroupAggregation Aggregated case counts for a single filter group key, with one entry per observed value.
 type FilterGroupAggregation struct {
 	// Filter group key
-	Key *string `json:"key,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Key *string `json:"key,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Aggregations per value
 	ValueCounts []ValueCount `json:"valueCounts"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_generic_indicator.go
+++ b/go/openapi/gen/cases_service/model_generic_indicator.go
@@ -27,7 +27,7 @@ type GenericIndicator struct {
 	// URLs to the originating entities in the external system.
 	EntityLinks []EntityLink `json:"entityLinks,omitempty"`
 	// Opaque reference to the originating entity in the external system.
-	ExternalId string `json:"externalId" validate:"regexp=^[\\\\s\\\\S]*$"`
+	ExternalId string `json:"externalId" validate:"regexp=^[\\s\\S]*$"`
 	// Unique identifier of this generic indicator.
 	Id string `json:"id" validate:"regexp=^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"`
 	IndicatorType GenericIndicatorType `json:"indicatorType"`

--- a/go/openapi/gen/cases_service/model_olly_analysis_payload.go
+++ b/go/openapi/gen/cases_service/model_olly_analysis_payload.go
@@ -26,11 +26,11 @@ type OllyAnalysisPayload struct {
 	// Timestamp when the analysis was generated.
 	GeneratedAt *time.Time `json:"generatedAt,omitempty"`
 	// Natural-language summary of the Olly investigation.
-	InvestigationSummary *string `json:"investigationSummary,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	InvestigationSummary *string `json:"investigationSummary,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Ordered list of remediation steps, one recommendation per element.
 	RemediationRecommendations []string `json:"remediationRecommendations,omitempty"`
 	// Olly's hypothesised root cause for the case.
-	RootCause *string `json:"rootCause,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	RootCause *string `json:"rootCause,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	RootCauseConfidence *OllyAnalysisRootCauseConfidence `json:"rootCauseConfidence,omitempty"`
 	AdditionalProperties map[string]interface{}
 }

--- a/go/openapi/gen/cases_service/model_prometheus_alert.go
+++ b/go/openapi/gen/cases_service/model_prometheus_alert.go
@@ -25,17 +25,17 @@ var _ MappedNullable = &PrometheusAlert{}
 // PrometheusAlert Data describing a single Prometheus alert within an alert group.
 type PrometheusAlert struct {
 	// Identifier of the Prometheus alerts group this alert belongs to.
-	AlertGroupId string `json:"alertGroupId" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AlertGroupId string `json:"alertGroupId" validate:"regexp=^[\\s\\S]*$"`
 	// Name of the alert (typically the `alertname` label).
-	AlertName string `json:"alertName" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AlertName string `json:"alertName" validate:"regexp=^[\\s\\S]*$"`
 	// Annotations attached to the alert.
 	Annotations map[string]string `json:"annotations"`
 	// Timestamp when the alert was first observed.
 	CreatedAt time.Time `json:"createdAt"`
 	// Prometheus alert fingerprint (stable identifier for this alert instance).
-	Fingerprint string `json:"fingerprint" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Fingerprint string `json:"fingerprint" validate:"regexp=^[\\s\\S]*$"`
 	// URL of the system that generated the alert.
-	GeneratorUrl string `json:"generatorUrl" validate:"regexp=^[\\\\s\\\\S]*$"`
+	GeneratorUrl string `json:"generatorUrl" validate:"regexp=^[\\s\\S]*$"`
 	// Labels attached to the alert.
 	Labels map[string]string `json:"labels"`
 	Priority IndicatorPriority `json:"priority"`

--- a/go/openapi/gen/cases_service/model_prometheus_alert_indicator.go
+++ b/go/openapi/gen/cases_service/model_prometheus_alert_indicator.go
@@ -25,18 +25,18 @@ var _ MappedNullable = &PrometheusAlertIndicator{}
 // PrometheusAlertIndicator Data describing a triggered Prometheus alert group and its constituent alerts.
 type PrometheusAlertIndicator struct {
 	// Identifier of the Prometheus alerts group.
-	AlertGroupId string `json:"alertGroupId" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AlertGroupId string `json:"alertGroupId" validate:"regexp=^[\\s\\S]*$"`
 	// Individual alerts contained in this group.
 	Alerts []PrometheusAlert `json:"alerts"`
 	// External URL of the Alertmanager instance that emitted the group.
-	ExternalUrl string `json:"externalUrl" validate:"regexp=^[\\\\s\\\\S]*$"`
+	ExternalUrl string `json:"externalUrl" validate:"regexp=^[\\s\\S]*$"`
 	// Labels used to group the alerts.
 	GroupLabels map[string]string `json:"groupLabels"`
 	Priority IndicatorPriority `json:"priority"`
 	// Timestamp when the alert group was first received.
 	ReceivedAt time.Time `json:"receivedAt"`
 	// Name of the Alertmanager receiver that handled the group.
-	Receiver string `json:"receiver" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Receiver string `json:"receiver" validate:"regexp=^[\\s\\S]*$"`
 	Status PrometheusAlertStatus `json:"status"`
 	// Timestamp when the alert group was last updated.
 	UpdatedAt time.Time `json:"updatedAt"`

--- a/go/openapi/gen/cases_service/model_prometheus_alert_manager_indicator.go
+++ b/go/openapi/gen/cases_service/model_prometheus_alert_manager_indicator.go
@@ -25,7 +25,7 @@ var _ MappedNullable = &PrometheusAlertManagerIndicator{}
 // PrometheusAlertManagerIndicator Lookup keys identifying a specific Prometheus AlertManager alert episode.
 type PrometheusAlertManagerIndicator struct {
 	// Prometheus alert fingerprint — the stable, label-derived hash that identifies this alert across firings.
-	Fingerprint string `json:"fingerprint" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Fingerprint string `json:"fingerprint" validate:"regexp=^[\\s\\S]*$"`
 	// ISO-8601 timestamp of when the alert episode began (the `startsAt` field from Prometheus AlertManager).
 	StartedAt time.Time `json:"startedAt"`
 	AdditionalProperties map[string]interface{}

--- a/go/openapi/gen/cases_service/model_prometheus_alert_query.go
+++ b/go/openapi/gen/cases_service/model_prometheus_alert_query.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &PrometheusAlertQuery{}
 // PrometheusAlertQuery Query backing a Prometheus alert.
 type PrometheusAlertQuery struct {
 	// PromQL expression that triggered the alert.
-	Promql string `json:"promql" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Promql string `json:"promql" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_resolution_details.go
+++ b/go/openapi/gen/cases_service/model_resolution_details.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &ResolutionDetails{}
 // ResolutionDetails Information about how and when a case was resolved.
 type ResolutionDetails struct {
 	// Resolution reason
-	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Timestamp when the case was resolved
 	ResolveTime *time.Time `json:"resolveTime,omitempty"`
 	ResolvedBy *CaseResolver `json:"resolvedBy,omitempty"`

--- a/go/openapi/gen/cases_service/model_resolve_case_request.go
+++ b/go/openapi/gen/cases_service/model_resolve_case_request.go
@@ -23,7 +23,7 @@ var _ MappedNullable = &ResolveCaseRequest{}
 // ResolveCaseRequest Request to mark a case as resolved.
 type ResolveCaseRequest struct {
 	// Reason to resolve
-	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Reason *string `json:"reason,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/cases_service/model_value_count.go
+++ b/go/openapi/gen/cases_service/model_value_count.go
@@ -25,7 +25,7 @@ type ValueCount struct {
 	// Count of cases for this value
 	Count *int64 `json:"count,omitempty"`
 	// Filter value
-	Value *string `json:"value,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Value *string `json:"value,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/dashboard_service/model_check_dashboard_request_dashboard.go
+++ b/go/openapi/gen/dashboard_service/model_check_dashboard_request_dashboard.go
@@ -25,7 +25,7 @@ var _ MappedNullable = &CheckDashboardRequestDashboard{}
 type CheckDashboardRequestDashboard struct {
 	Dashboard Dashboard `json:"dashboard"`
 	// Optional idempotency key for the check request
-	RequestId *string `json:"requestId,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	RequestId *string `json:"requestId,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/dashboard_service/model_check_dashboard_request_dashboard_id.go
+++ b/go/openapi/gen/dashboard_service/model_check_dashboard_request_dashboard_id.go
@@ -24,9 +24,9 @@ var _ MappedNullable = &CheckDashboardRequestDashboardId{}
 // CheckDashboardRequestDashboardId Validate a dashboard definition or an existing dashboard by id
 type CheckDashboardRequestDashboardId struct {
 	// Id of an existing dashboard to load and validate
-	DashboardId string `json:"dashboardId" validate:"regexp=^[\\\\s\\\\S]*$"`
+	DashboardId string `json:"dashboardId" validate:"regexp=^[\\s\\S]*$"`
 	// Optional idempotency key for the check request
-	RequestId *string `json:"requestId,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	RequestId *string `json:"requestId,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/go/openapi/gen/dashboard_service/model_create_dashboard_request_data_structure.go
+++ b/go/openapi/gen/dashboard_service/model_create_dashboard_request_data_structure.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &CreateDashboardRequestDataStructure{}
 // CreateDashboardRequestDataStructure This is a request used to create a new custom dashboard
 type CreateDashboardRequestDataStructure struct {
 	// JSON string representing the access policy for this dashboard. Defines granular permissions for users and groups.
-	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	Dashboard Dashboard `json:"dashboard"`
 	// The is locked.
 	IsLocked *bool `json:"isLocked,omitempty"`

--- a/go/openapi/gen/dashboard_service/model_get_dashboard_by_slug_response.go
+++ b/go/openapi/gen/dashboard_service/model_get_dashboard_by_slug_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &GetDashboardBySlugResponse{}
 // GetDashboardBySlugResponse This is a response containing the requested dashboard
 type GetDashboardBySlugResponse struct {
 	// JSON string representing the access policy for this dashboard. Defines granular permissions for users and groups.
-	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// The author id.
 	AuthorId *string `json:"authorId,omitempty"`
 	// The author name.

--- a/go/openapi/gen/dashboard_service/model_get_dashboard_response.go
+++ b/go/openapi/gen/dashboard_service/model_get_dashboard_response.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &GetDashboardResponse{}
 // GetDashboardResponse This is a response containing the requested dashboard
 type GetDashboardResponse struct {
 	// JSON string representing the access policy for this dashboard. Defines granular permissions for users and groups.
-	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// The author id.
 	AuthorId *string `json:"authorId,omitempty"`
 	// The author name.

--- a/go/openapi/gen/dashboard_service/model_issue.go
+++ b/go/openapi/gen/dashboard_service/model_issue.go
@@ -23,9 +23,9 @@ var _ MappedNullable = &Issue{}
 // Issue struct for Issue
 type Issue struct {
 	// Location of the issue within the dashboard as an RFC 6901 JSON Pointer (e.g. \"/sections/0/rows/1/widgets/2\"). Empty or omitted for root-level issues.
-	Location *string `json:"location,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Location *string `json:"location,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	// Human-readable description of the issue
-	Message *string `json:"message,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	Message *string `json:"message,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	Severity *IssueSeverity `json:"severity,omitempty"`
 	AdditionalProperties map[string]interface{}
 }

--- a/go/openapi/gen/dashboard_service/model_replace_dashboard_request_data_structure.go
+++ b/go/openapi/gen/dashboard_service/model_replace_dashboard_request_data_structure.go
@@ -24,7 +24,7 @@ var _ MappedNullable = &ReplaceDashboardRequestDataStructure{}
 // ReplaceDashboardRequestDataStructure This is a request sent to update an existing dashboard with new information
 type ReplaceDashboardRequestDataStructure struct {
 	// JSON string representing the access policy for this dashboard. Defines granular permissions for users and groups.
-	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\\\s\\\\S]*$"`
+	AccessPolicy *string `json:"accessPolicy,omitempty" validate:"regexp=^[\\s\\S]*$"`
 	Dashboard Dashboard `json:"dashboard"`
 	// The is locked.
 	IsLocked *bool `json:"isLocked,omitempty"`

--- a/go/scripts/generate_openapi.sh
+++ b/go/scripts/generate_openapi.sh
@@ -15,48 +15,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPECS_DIR="specs"
 OUT_BASE="go/openapi/gen"
 TEMPLATE_DIR="go/openapi/templates"
 OPENAPI_TOOLS_CONFIG="openapitools.json"
 
-run_openapi_generator() {
-  if command -v openapi-generator-cli >/dev/null 2>&1; then
-    openapi-generator-cli "$@"
-    return
-  fi
-
-  if command -v openapi-generator >/dev/null 2>&1; then
-    openapi-generator "$@"
-    return
-  fi
-
-  if command -v npx >/dev/null 2>&1 && java -version >/dev/null 2>&1; then
-    npx --yes @openapitools/openapi-generator-cli "$@"
-    return
-  fi
-
-  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-    local generator_version
-    generator_version="$(python3 - "$OPENAPI_TOOLS_CONFIG" <<'PY'
-import json
-import sys
-
-config = json.load(open(sys.argv[1]))
-print(config["generator-cli"]["version"])
-PY
-)"
-    docker run --rm \
-      -v "$PWD:/local" \
-      -w /local \
-      "openapitools/openapi-generator-cli:v${generator_version}" \
-      "$@"
-    return
-  fi
-
-  echo "openapi-generator-cli requires either a local CLI, a working Java runtime, or Docker" >&2
-  return 127
-}
+source "$SCRIPT_DIR/openapi_generator_common.sh"
 
 rm -rf "$OUT_BASE"
 
@@ -80,4 +45,6 @@ for spec in "$SPECS_DIR"/*; do
       echo "FAILED to generate for $filename"
       continue
   fi
+
+  normalize_regex_validator_tags "$outdir"
 done

--- a/go/scripts/openapi_generator_common.sh
+++ b/go/scripts/openapi_generator_common.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+run_openapi_generator() {
+  if command -v openapi-generator-cli >/dev/null 2>&1; then
+    openapi-generator-cli "$@"
+    return
+  fi
+
+  if command -v openapi-generator >/dev/null 2>&1; then
+    openapi-generator "$@"
+    return
+  fi
+
+  if command -v npx >/dev/null 2>&1 && java -version >/dev/null 2>&1; then
+    npx --yes @openapitools/openapi-generator-cli "$@"
+    return
+  fi
+
+  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+    local generator_version
+    generator_version="$(python3 - "${OPENAPI_TOOLS_CONFIG:?OPENAPI_TOOLS_CONFIG must be set}" <<'PY'
+import json
+import sys
+
+config = json.load(open(sys.argv[1]))
+print(config["generator-cli"]["version"])
+PY
+)"
+    docker run --rm \
+      -v "$PWD:/local" \
+      -w /local \
+      "openapitools/openapi-generator-cli:v${generator_version}" \
+      "$@"
+    return
+  fi
+
+  echo "openapi-generator-cli requires either a local CLI, a working Java runtime, or Docker" >&2
+  return 127
+}
+
+normalize_regex_validator_tags() {
+  local outdir="$1"
+
+  # OpenAPI Generator over-escapes \s and \S in Go struct tags. Four
+  # backslashes in the generated source become two backslashes after
+  # reflect.StructTag parsing, which changes the regexp semantics.
+  find "$outdir" -type f -name '*.go' -exec perl -0pi -e '1 while s/(validate:"regexp=[^"`]*)\\{4}([sS])/$1\\\\$2/g' {} +
+}

--- a/go/scripts/test_openapi_compat.sh
+++ b/go/scripts/test_openapi_compat.sh
@@ -2,49 +2,14 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 FIXTURES_DIR="$REPO_ROOT/go/openapi/testdata/compat"
 WORK_DIR="$REPO_ROOT/go/openapi/testdata/.compat-tmp"
 TEMPLATE_DIR="$REPO_ROOT/go/openapi/templates"
 OPENAPI_TOOLS_CONFIG="$REPO_ROOT/openapitools.json"
 
-run_openapi_generator() {
-  if command -v openapi-generator-cli >/dev/null 2>&1; then
-    openapi-generator-cli "$@"
-    return
-  fi
-
-  if command -v openapi-generator >/dev/null 2>&1; then
-    openapi-generator "$@"
-    return
-  fi
-
-  if command -v npx >/dev/null 2>&1 && java -version >/dev/null 2>&1; then
-    npx --yes @openapitools/openapi-generator-cli "$@"
-    return
-  fi
-
-  if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
-    local generator_version
-    generator_version="$(python3 - "$OPENAPI_TOOLS_CONFIG" <<'PY'
-import json
-import sys
-
-config = json.load(open(sys.argv[1]))
-print(config["generator-cli"]["version"])
-PY
-)"
-    docker run --rm \
-      -v "$PWD:/local" \
-      -w /local \
-      "openapitools/openapi-generator-cli:v${generator_version}" \
-      "$@"
-    return
-  fi
-
-  echo "openapi-generator-cli requires either a local CLI, a working Java runtime, or Docker" >&2
-  return 127
-}
+source "$SCRIPT_DIR/openapi_generator_common.sh"
 
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
@@ -71,6 +36,8 @@ for fixture_dir in "$FIXTURES_DIR"/*; do
     --template-dir="$template_rel" \
     --additional-properties=withGoMod=false,packageName="$package_name",enumClassPrefix=true,disallowAdditionalPropertiesIfNotPresent=false \
     --global-property=apiTests=false,modelTests=false,apiDocs=false,modelDocs=false >/dev/null
+
+  normalize_regex_validator_tags "$outdir"
 
   cp "$fixture_dir/compat_test.go" "$outdir/compat_test.go"
 


### PR DESCRIPTION
Fixes over-escaped \s \S regex patterns in generated Go validator tags by normalizing them after OpenAPI Generator runs. This prevents oneOf decoding from dropping valid AI evaluation configs such as promptInjection and customEvaluation.
Added regression tests in the AI OpenAPI examples to verify those config variants decode correctly.