### PR TITLE
Fix gRPC/REST endpoint resolution for custom (BYOC) domains

### DIFF
--- a/go/cxsdk.go
+++ b/go/cxsdk.go
@@ -370,8 +370,27 @@ func CoralogixGrpcEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return GrpcAP3
 	default:
-		return fmt.Sprintf("ng-api-grpc.%s:443", regionIdentifier)
+		return CoralogixGrpcEndpointFromDomain(regionIdentifier)
 	}
+}
+
+// normalizeCoralogixDomain reduces a Coralogix domain to its base form by
+// stripping a leading "api." label. The OpenAPI/REST client identifies a
+// tenant by its API host (e.g. "api.eu2.coralogix.com"), whereas the gRPC and
+// ng-api REST endpoints are derived by prefixing the base domain
+// (e.g. "eu2.coralogix.com") with "ng-api-grpc." / "ng-api-http.". Normalizing
+// here lets callers pass either form interchangeably and still reach the
+// correct host for every protocol.
+func normalizeCoralogixDomain(domain string) string {
+	return strings.TrimPrefix(domain, "api.")
+}
+
+// CoralogixGrpcEndpointFromDomain returns the gRPC endpoint for a custom
+// Coralogix domain (e.g. "eu2.coralogix.com" or "mycompany.coralogix.com").
+// A leading "api." is tolerated so the same domain value used to configure the
+// OpenAPI/REST client also yields the correct gRPC host.
+func CoralogixGrpcEndpointFromDomain(domain string) string {
+	return fmt.Sprintf("ng-api-grpc.%s:443", normalizeCoralogixDomain(domain))
 }
 
 // CoralogixRestEndpointFromRegion reads the Coralogix REST endpoint from environment variables.
@@ -394,8 +413,16 @@ func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return RestAP3
 	default:
-		return fmt.Sprintf("https://ng-api-http.%s", regionIdentifier)
+		return CoralogixRestEndpointFromDomain(regionIdentifier)
 	}
+}
+
+// CoralogixRestEndpointFromDomain returns the ng-api REST endpoint for a custom
+// Coralogix domain (e.g. "eu2.coralogix.com" or "mycompany.coralogix.com").
+// A leading "api." is tolerated so the same domain value used to configure the
+// OpenAPI client also yields the correct REST host.
+func CoralogixRestEndpointFromDomain(domain string) string {
+	return fmt.Sprintf("https://ng-api-http.%s", normalizeCoralogixDomain(domain))
 }
 
 // AuthContext is a struct that holds the API keys for the Coralogix SDK.

--- a/go/endpoint_resolution_test.go
+++ b/go/endpoint_resolution_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cxsdk
+
+import "testing"
+
+func TestCoralogixGrpcEndpointFromRegion(t *testing.T) {
+	cases := map[string]string{
+		// Known regions keep their hardcoded endpoints.
+		"eu2": GrpcEU2,
+		"us1": GrpcUS1,
+		// A base custom/BYOC domain is prefixed with ng-api-grpc.
+		"factset.coralogix.com": "ng-api-grpc.factset.coralogix.com:443",
+		// The OpenAPI host form ("api.<domain>") must resolve to the SAME
+		// gRPC host, not a double-prefixed "ng-api-grpc.api.<domain>".
+		"api.factset.coralogix.com": "ng-api-grpc.factset.coralogix.com:443",
+	}
+	for in, want := range cases {
+		if got := CoralogixGrpcEndpointFromRegion(in); got != want {
+			t.Errorf("CoralogixGrpcEndpointFromRegion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCoralogixGrpcEndpointFromDomain(t *testing.T) {
+	cases := map[string]string{
+		"factset.coralogix.com":     "ng-api-grpc.factset.coralogix.com:443",
+		"api.factset.coralogix.com": "ng-api-grpc.factset.coralogix.com:443",
+		"eu2.coralogix.com":         "ng-api-grpc.eu2.coralogix.com:443",
+	}
+	for in, want := range cases {
+		if got := CoralogixGrpcEndpointFromDomain(in); got != want {
+			t.Errorf("CoralogixGrpcEndpointFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCoralogixRestEndpointFromDomain(t *testing.T) {
+	cases := map[string]string{
+		"factset.coralogix.com":     "https://ng-api-http.factset.coralogix.com",
+		"api.factset.coralogix.com": "https://ng-api-http.factset.coralogix.com",
+	}
+	for in, want := range cases {
+		if got := CoralogixRestEndpointFromDomain(in); got != want {
+			t.Errorf("CoralogixRestEndpointFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/go/openapi/cxsdk/config.go
+++ b/go/openapi/cxsdk/config.go
@@ -218,11 +218,20 @@ func URLFromRegion(region string) (string, bool) {
 }
 
 // URLFromDomain returns the Coralogix OpenAPI URL for the given custom domain.
+//
+// The OpenAPI host is derived from the base Coralogix domain by prefixing it
+// with "api.", consistent with URLFromRegion (e.g. domain "eu2.coralogix.com"
+// resolves to "api.eu2.coralogix.com"). A domain that already carries the
+// "api." prefix is accepted as-is for backward compatibility.
 func URLFromDomain(domain string) string {
+	host := domain
+	if !strings.HasPrefix(host, "api.") {
+		host = "api." + host
+	}
 	url := gourl.URL{
 		Scheme: "https",
 		Path:   "mgmt/openapi/5",
-		Host:   domain,
+		Host:   host,
 	}
 	return url.String()
 }

--- a/go/openapi/cxsdk/config_test.go
+++ b/go/openapi/cxsdk/config_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cxsdk
+
+import "testing"
+
+func TestURLFromDomain(t *testing.T) {
+	cases := map[string]string{
+		// A base domain is prefixed with "api.", matching URLFromRegion.
+		"factset.coralogix.com": "https://api.factset.coralogix.com/mgmt/openapi/5",
+		"eu2.coralogix.com":     "https://api.eu2.coralogix.com/mgmt/openapi/5",
+		// A domain that already carries the "api." prefix is used as-is
+		// (backward compatible, no double prefix).
+		"api.factset.coralogix.com": "https://api.factset.coralogix.com/mgmt/openapi/5",
+	}
+	for in, want := range cases {
+		if got := URLFromDomain(in); got != want {
+			t.Errorf("URLFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestURLFromDomainMatchesRegion(t *testing.T) {
+	// The custom-domain path for a standard region must produce the same URL
+	// as the region path, so both configuration styles are interchangeable.
+	want, ok := URLFromRegion("eu2")
+	if !ok {
+		t.Fatal("URLFromRegion(eu2) reported invalid")
+	}
+	if got := URLFromDomain("eu2.coralogix.com"); got != want {
+		t.Errorf("URLFromDomain(eu2.coralogix.com) = %q, want %q (URLFromRegion)", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

The gRPC client and the OpenAPI/REST client resolve a custom **domain** differently, so no single domain value satisfies both clients at once.

| Resolver | Treats `domain` as | Result for `api.factset.coralogix.com` |
|---|---|---|
| `CoralogixGrpcEndpointFromRegion` (default branch) | base domain → prefixes `ng-api-grpc.` | `ng-api-grpc.api.factset.coralogix.com:443` ❌ |
| `URLFromDomain` (OpenAPI) | full API host, used verbatim | `https://api.factset.coralogix.com/mgmt/openapi/5` ✅ |

`URLFromRegion` already derives `api.<base>` (e.g. `eu2` → `api.eu2.coralogix.com`), and the gRPC/ng-api-http constants derive `ng-api-grpc.<base>` / `ng-api-http.<base>` from the same base domain (e.g. `eu2.coralogix.com`). `URLFromDomain` is the outlier — it expects the `api.`-prefixed host, while the gRPC resolver expects the base. There's also no domain-specific gRPC/REST resolver, forcing consumers to misuse `*FromRegion`.

### Real-world impact (Coralogix operator, BYOC)

The operator surfaces a single `--domain` flag and feeds it to both clients. A FactSet BYOC tenant configured `--domain api.factset.coralogix.com`:

- Folder controller (OpenAPI) → `api.factset.coralogix.com` ✅
- Dashboard controller (gRPC) → `ng-api-grpc.api.factset.coralogix.com` ❌

Verified against live DNS / reflection:

```
$ dig +short ng-api-grpc.factset.coralogix.com        # 104.18.8.21, 104.18.9.21
$ dig +short ng-api-grpc.api.factset.coralogix.com     # (empty — NXDOMAIN)
$ grpcurl ng-api-grpc.factset.coralogix.com:443 list   # works; serves DashboardsService
$ grpcurl ng-api-grpc.api.factset.coralogix.com:443 list
  Failed to dial ... lookup ng-api-grpc.api.factset.coralogix.com: no such host
```

So the dashboard controller fails with NXDOMAIN, not a TLS/egress rejection.

## Fix

Establish the documented **base Coralogix domain** (e.g. `eu2.coralogix.com`, `factset.coralogix.com`) as the single convention across protocols:

- Add `CoralogixGrpcEndpointFromDomain` / `CoralogixRestEndpointFromDomain`; route the `*FromRegion` default branches through them.
- Normalize a leading `api.` so callers may pass **either** the base domain or the OpenAPI host form and still reach the correct host for every protocol.
- Make `URLFromDomain` prefix `api.` (consistent with `URLFromRegion`), accepting an already-prefixed domain for backward compatibility.

After this change, `eu2.coralogix.com`, `factset.coralogix.com`, and their `api.`-prefixed forms all resolve to the correct gRPC, ng-api REST, and OpenAPI hosts.

## Discussion points for reviewers

- **`api.` normalization** is a pragmatic guard so the same `--domain` works for both clients regardless of which form a user provides. Alternative: require the base domain strictly and treat any `api.`-prefixed input as invalid. Preference?
- `URLFromDomain` behavior changes for **base** domains (now `api.`-prefixed); `api.`-prefixed inputs are unchanged. Confirm no internal caller depends on the old verbatim-host behavior for a non-`api.` host.

## Tests

- `go/endpoint_resolution_test.go` — gRPC/REST resolution for base and `api.`-prefixed forms, plus known regions.
- `go/openapi/cxsdk/config_test.go` — `URLFromDomain` for both forms and parity with `URLFromRegion`.

## Follow-up

A companion operator change can adopt these and document that `--domain` accepts the base Coralogix domain. No operator code change is strictly required: the existing `api.`-prefixed config now resolves correctly through the normalized `*FromRegion` default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)