### PR TITLE
Fix gRPC/REST endpoint resolution for custom (BYOC) domains

### DIFF
--- a/go/cxsdk.go
+++ b/go/cxsdk.go
@@ -370,8 +370,27 @@ func CoralogixGrpcEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return GrpcAP3
 	default:
-		return fmt.Sprintf("ng-api-grpc.%s:443", regionIdentifier)
+		return CoralogixGrpcEndpointFromDomain(regionIdentifier)
 	}
+}
+
+// normalizeCoralogixDomain reduces a Coralogix domain to its base form by
+// stripping a leading "api." label. The OpenAPI/REST client identifies a
+// tenant by its API host (e.g. "api.eu2.coralogix.com"), whereas the gRPC and
+// ng-api REST endpoints are derived by prefixing the base domain
+// (e.g. "eu2.coralogix.com") with "ng-api-grpc." / "ng-api-http.". Normalizing
+// here lets callers pass either form interchangeably and still reach the
+// correct host for every protocol.
+func normalizeCoralogixDomain(domain string) string {
+	return strings.TrimPrefix(domain, "api.")
+}
+
+// CoralogixGrpcEndpointFromDomain returns the gRPC endpoint for a custom
+// Coralogix domain (e.g. "eu2.coralogix.com" or "mycompany.coralogix.com").
+// A leading "api." is tolerated so the same domain value used to configure the
+// OpenAPI/REST client also yields the correct gRPC host.
+func CoralogixGrpcEndpointFromDomain(domain string) string {
+	return fmt.Sprintf("ng-api-grpc.%s:443", normalizeCoralogixDomain(domain))
 }
 
 // CoralogixRestEndpointFromRegion reads the Coralogix REST endpoint from environment variables.
@@ -394,8 +413,16 @@ func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
 	case "ap3":
 		return RestAP3
 	default:
-		return fmt.Sprintf("https://ng-api-http.%s", regionIdentifier)
+		return CoralogixRestEndpointFromDomain(regionIdentifier)
 	}
+}
+
+// CoralogixRestEndpointFromDomain returns the ng-api REST endpoint for a custom
+// Coralogix domain (e.g. "eu2.coralogix.com" or "mycompany.coralogix.com").
+// A leading "api." is tolerated so the same domain value used to configure the
+// OpenAPI client also yields the correct REST host.
+func CoralogixRestEndpointFromDomain(domain string) string {
+	return fmt.Sprintf("https://ng-api-http.%s", normalizeCoralogixDomain(domain))
 }
 
 // AuthContext is a struct that holds the API keys for the Coralogix SDK.

--- a/go/endpoint_resolution_test.go
+++ b/go/endpoint_resolution_test.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cxsdk
+
+import "testing"
+
+func TestCoralogixGrpcEndpointFromRegion(t *testing.T) {
+	cases := map[string]string{
+		// Known region shorthands resolve to the documented gRPC hosts.
+		"eu2": GrpcEU2,
+		"us1": GrpcUS1,
+		// A base custom/BYOC domain is prefixed with ng-api-grpc.
+		"acme.coralogix.com": "ng-api-grpc.acme.coralogix.com:443",
+		// The OpenAPI host form ("api.<domain>") is normalized to the base
+		// gRPC host, not a double-prefixed "ng-api-grpc.api.<domain>".
+		"api.acme.coralogix.com": "ng-api-grpc.acme.coralogix.com:443",
+	}
+	for in, want := range cases {
+		if got := CoralogixGrpcEndpointFromRegion(in); got != want {
+			t.Errorf("CoralogixGrpcEndpointFromRegion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCoralogixGrpcEndpointFromDomain(t *testing.T) {
+	cases := map[string]string{
+		"acme.coralogix.com":      "ng-api-grpc.acme.coralogix.com:443",
+		"api.acme.coralogix.com":  "ng-api-grpc.acme.coralogix.com:443",
+		"mycompany.coralogix.com": "ng-api-grpc.mycompany.coralogix.com:443",
+	}
+	for in, want := range cases {
+		if got := CoralogixGrpcEndpointFromDomain(in); got != want {
+			t.Errorf("CoralogixGrpcEndpointFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCoralogixRestEndpointFromRegion(t *testing.T) {
+	cases := map[string]string{
+		"eu2":                    RestEU2,
+		"acme.coralogix.com":     "https://ng-api-http.acme.coralogix.com",
+		"api.acme.coralogix.com": "https://ng-api-http.acme.coralogix.com",
+	}
+	for in, want := range cases {
+		if got := CoralogixRestEndpointFromRegion(in); got != want {
+			t.Errorf("CoralogixRestEndpointFromRegion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCoralogixRestEndpointFromDomain(t *testing.T) {
+	cases := map[string]string{
+		"acme.coralogix.com":     "https://ng-api-http.acme.coralogix.com",
+		"api.acme.coralogix.com": "https://ng-api-http.acme.coralogix.com",
+	}
+	for in, want := range cases {
+		if got := CoralogixRestEndpointFromDomain(in); got != want {
+			t.Errorf("CoralogixRestEndpointFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/go/openapi/cxsdk/config.go
+++ b/go/openapi/cxsdk/config.go
@@ -218,11 +218,20 @@ func URLFromRegion(region string) (string, bool) {
 }
 
 // URLFromDomain returns the Coralogix OpenAPI URL for the given custom domain.
+//
+// The OpenAPI host is derived from the base Coralogix domain by prefixing it
+// with "api.", consistent with URLFromRegion (e.g. domain "eu2.coralogix.com"
+// resolves to "api.eu2.coralogix.com"). A domain that already carries the
+// "api." prefix is accepted as-is for backward compatibility.
 func URLFromDomain(domain string) string {
+	host := domain
+	if !strings.HasPrefix(host, "api.") {
+		host = "api." + host
+	}
 	url := gourl.URL{
 		Scheme: "https",
 		Path:   "mgmt/openapi/5",
-		Host:   domain,
+		Host:   host,
 	}
 	return url.String()
 }

--- a/go/openapi/cxsdk/config_test.go
+++ b/go/openapi/cxsdk/config_test.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cxsdk
+
+import "testing"
+
+func TestURLFromDomain(t *testing.T) {
+	cases := map[string]string{
+		// The base domain is prefixed with "api." to form the OpenAPI host.
+		"acme.coralogix.com": "https://api.acme.coralogix.com/mgmt/openapi/5",
+		// An already-prefixed domain is accepted as-is (no double "api.").
+		"api.acme.coralogix.com":  "https://api.acme.coralogix.com/mgmt/openapi/5",
+		"mycompany.coralogix.com": "https://api.mycompany.coralogix.com/mgmt/openapi/5",
+	}
+	for in, want := range cases {
+		if got := URLFromDomain(in); got != want {
+			t.Errorf("URLFromDomain(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestURLFromDomainMatchesURLFromRegion(t *testing.T) {
+	// Passing a region's base domain to URLFromDomain must yield the same host
+	// that URLFromRegion produces for that region, so the two configuration
+	// paths are interchangeable.
+	want, ok := URLFromRegion("eu2")
+	if !ok {
+		t.Fatal("URLFromRegion(\"eu2\") returned not-ok")
+	}
+	if got := URLFromDomain("eu2.coralogix.com"); got != want {
+		t.Errorf("URLFromDomain(\"eu2.coralogix.com\") = %q, want %q (URLFromRegion parity)", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

The gRPC and OpenAPI clients disagree on what a "domain" is, so a single domain value cannot satisfy both:

- `CoralogixGrpcEndpointFromRegion`'s default branch prefixes the raw input with `ng-api-grpc.` (treating it as a **base** domain).
- `URLFromDomain` uses the value **verbatim** as the OpenAPI host (treating it as the `api.`-prefixed host).

A consumer such as the **Coralogix operator** passes a single `--domain` / `CORALOGIX_DOMAIN` to both clients. So configuring the OpenAPI host `api.acme.coralogix.com` produces the non-existent gRPC host `ng-api-grpc.api.acme.coralogix.com` (NXDOMAIN), while the correct host is `ng-api-grpc.acme.coralogix.com`. Conversely, passing the base domain fixes gRPC but breaks the OpenAPI host. **No single value works for both.**

| `CORALOGIX_DOMAIN` | OpenAPI (before) | gRPC (before) |
|---|---|---|
| `api.acme.coralogix.com` | ✅ correct | ❌ `ng-api-grpc.api.acme…` |
| `acme.coralogix.com` | ❌ `https://acme…` (no `api.`) | ✅ correct |

## Fix

Establish the documented **base** Coralogix domain (e.g. `eu2.coralogix.com`, `acme.coralogix.com`) as the single convention across protocols:

- Add `CoralogixGrpcEndpointFromDomain` / `CoralogixRestEndpointFromDomain` and route the `*FromRegion` default branches through them.
- Normalize a leading `api.` so the OpenAPI host form is accepted too — both gRPC and ng-api REST reach the correct host for either input form.
- Make `URLFromDomain` prefix `api.` (consistent with `URLFromRegion`), accepting an already-prefixed domain for backward compatibility.

After the fix, **either** input form resolves correctly for **every** protocol.

## Tests

`go/endpoint_resolution_test.go` and `go/openapi/cxsdk/config_test.go` cover both the base and `api.`-prefixed forms for all four functions, including the BYOC case (`api.acme.coralogix.com` → `ng-api-grpc.acme.coralogix.com:443`) and `URLFromRegion`/`URLFromDomain` parity.

## Notes

- Supersedes the earlier (closed) #648 with the same fix, rebased on current `master`.
- Once merged + released, the Coralogix operator needs only a dependency bump (no operator code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)