### PR TITLE
feat(dashboards): export public aliases for manual annotation source

### DIFF
--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -842,6 +842,27 @@ type AnnotationMetricsSourceStartTimeMetric = annotations.Annotation_MetricsSour
 // AnnotationMetricsSourceStrategyStartTimeMetric is an annotation variant.
 type AnnotationMetricsSourceStrategyStartTimeMetric = annotations.Annotation_MetricsSource_Strategy_StartTimeMetric
 
+// AnnotationSourceManual is an annotation variant.
+type AnnotationSourceManual = annotations.Annotation_Source_Manual
+
+// AnnotationManualSource is an annotation variant.
+type AnnotationManualSource = annotations.Annotation_ManualSource
+
+// AnnotationManualSourceStrategy is an annotation variant.
+type AnnotationManualSourceStrategy = annotations.Annotation_ManualSource_Strategy
+
+// AnnotationManualSourceStrategyInstant is an annotation variant.
+type AnnotationManualSourceStrategyInstant = annotations.Annotation_ManualSource_Strategy_Instant_
+
+// AnnotationManualSourceStrategyInstantInner is an annotation variant.
+type AnnotationManualSourceStrategyInstantInner = annotations.Annotation_ManualSource_Strategy_Instant
+
+// AnnotationManualSourceStrategyRange is an annotation variant.
+type AnnotationManualSourceStrategyRange = annotations.Annotation_ManualSource_Strategy_Range_
+
+// AnnotationManualSourceStrategyRangeInner is an annotation variant.
+type AnnotationManualSourceStrategyRangeInner = annotations.Annotation_ManualSource_Strategy_Range
+
 // DashboardLayout is a dashboard layout type.
 type DashboardLayout = ast.Layout
 


### PR DESCRIPTION
## What

Adds public `cxsdk` type aliases in `go/dashboards-client.go` for the **manual** annotation source on dashboards:

- `AnnotationSourceManual`
- `AnnotationManualSource`
- `AnnotationManualSourceStrategy`
- `AnnotationManualSourceStrategyInstant` / `...InstantInner`
- `AnnotationManualSourceStrategyRange` / `...RangeInner`

## Why

The generated types already exist under `internal/coralogixapis/dashboards/v1/ast/annotations`, but only `metrics`, `logs`, and `spans` were re-exported as public `cxsdk.*` aliases — `manual` was the only annotation source missing. Because it lives in `internal/`, external consumers (the Terraform provider) cannot reference it.

This mirrors the existing metrics/logs/spans alias blocks exactly (same naming, doc comments). Hand-written aliases only — **no codegen change, no proto change**.

## Impact

Unblocks terraform-provider-coralogix issue 507 (manual annotations in `coralogix_dashboard`). Additive, backward-compatible.

- `gofmt` clean
- `go build ./...` passes

Happy to adjust naming if you'd prefer a different convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)