### PR TITLE
feat(dashboards): export public alias for annotation orientation enum

### DIFF
--- a/go/dashboards-client.go
+++ b/go/dashboards-client.go
@@ -863,6 +863,15 @@ type AnnotationManualSourceStrategyRange = annotations.Annotation_ManualSource_S
 // AnnotationManualSourceStrategyRangeInner is an annotation variant.
 type AnnotationManualSourceStrategyRangeInner = annotations.Annotation_ManualSource_Strategy_Range
 
+// AnnotationOrientation is the orientation of a manual annotation.
+type AnnotationOrientation = annotations.Annotation_AnnotationOrientation
+
+// AnnotationOrientation values.
+const (
+	AnnotationOrientationVerticalUnspecified = annotations.Annotation_ANNOTATION_ORIENTATION_VERTICAL_UNSPECIFIED
+	AnnotationOrientationHorizontal          = annotations.Annotation_ANNOTATION_ORIENTATION_HORIZONTAL
+)
+
 // DashboardLayout is a dashboard layout type.
 type DashboardLayout = ast.Layout
 


### PR DESCRIPTION
Adds a public `cxsdk` alias and value constants for the dashboard annotation orientation enum — `AnnotationOrientation`, `AnnotationOrientationHorizontal`, `AnnotationOrientationVerticalUnspecified` — mirroring the existing `Unit` and annotation-source alias blocks.

The generated type already exists under `internal/`; this only re-exports it so consumers can reference it by name instead of a bare int32 literal. Additive, `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)