### PR TITLE
feat(dashboards): deprecate Dynamic widget interpretation field

### DIFF
--- a/proto/com/coralogixapis/dashboards/v1/ast/widgets/dynamic.proto
+++ b/proto/com/coralogixapis/dashboards/v1/ast/widgets/dynamic.proto
@@ -35,7 +35,10 @@ message Dynamic {
 
   v1.common.TimeFrameSelect time_frame = 2 [(grpc.gateway.protoc_gen_openapiv3.options.openapiv3_field) = {description: "Time frame which overrides the dashboard time frame"}];
 
-  Interpretation interpretation = 3 [(grpc.gateway.protoc_gen_openapiv3.options.openapiv3_field) = {description: "Interpretation of the query results"}];
+  Interpretation interpretation = 3 [
+    deprecated = true,
+    (grpc.gateway.protoc_gen_openapiv3.options.openapiv3_field) = {description: "Interpretation of the query results (deprecated, use visualization instead)"}
+  ];
 
   Visualization visualization = 4 [(grpc.gateway.protoc_gen_openapiv3.options.openapiv3_field) = {description: "Specifies how the query results should be visualized"}];
 


### PR DESCRIPTION
# User description
## Summary

Marks the `interpretation` field on the Dynamic widget (dashboards API) as deprecated. Consumers should use the `visualization` field instead, which is the supported replacement going forward.

This is an iteration that lands separately while being related to (but not directly part of) [CX-48065](https://coralogix.atlassian.net/browse/CX-48065).

## Changes

- `proto/com/coralogixapis/dashboards/v1/ast/widgets/dynamic.proto`: add `deprecated = true` to the `interpretation` field and update its description to point to `visualization`.
- `go/internal/coralogixapis/dashboards/v1/ast/widgets/dynamic.pb.go`: regenerated so the field declaration and `GetInterpretation` getter carry the `// Deprecated: Marked as deprecated in ...` comment, matching the existing pattern used for the deprecated `query` field.
- OpenAPI spec sources marked `interpretation` as `deprecated: true` with an updated description:
  - `openapi.yaml`
  - `specs/dashboard_service.json`
  - `tools/openapi-split/openapi.yaml`
  - `go/openapi/gen/dashboard_service/api/openapi.yaml`
- `go/openapi/gen/dashboard_service/model_widgets_dynamic.go`: added `// Deprecated` doc comments on the field and its accessors (`GetInterpretation`, `GetInterpretationOk`, `HasInterpretation`, `SetInterpretation`), mirroring the openapi-generator pattern used for other deprecated fields (e.g. `TextboxDefaultValueSingleNumeric`).

## Verification

- `go build ./...` passes.
- `go vet ./...` passes.
- Generated Go protobuf code was produced with `protoc-gen-go v1.36.11` (matching the version already checked into the repo) to keep the diff minimal.

Related Jira: [CX-48065](https://coralogix.atlassian.net/browse/CX-48065)
EOF 2>&1 | tail -10

[CX-48065]: https://coralogix.atlassian.net/browse/CX-48065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-48065]: https://coralogix.atlassian.net/browse/CX-48065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Mark the Dynamic widget <code>interpretation</code> field as deprecated in the dashboard AST proto and highlight <code>visualization</code> as the preferred replacement. Regenerate the associated OpenAPI sources and Go models so consumers see the deprecation reflected in clients and docs.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
<sub><a href="https://baz.co/changes/coralogix/coralogix-management-sdk/656?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>