### PR TITLE
Add dashboardjson helper for opaque dashboard JSON decode

### DIFF
--- a/go/openapi/dashboardjson/contract_test.go
+++ b/go/openapi/dashboardjson/contract_test.go
@@ -1,0 +1,386 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboardjson
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	dashboards "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+)
+
+// unmarshal_test.go pins these behaviours on hand-written samples. The tests here assert
+// they hold for every model reachable from Dashboard, so they keep covering the whole
+// schema as the pinned SDK is bumped.
+
+// Both spellings are injected because an unknown key that looks like a protobuf field
+// name takes a different route through normalizeProtoObjectFieldNames.
+const (
+	unknownCamelKey = "zzUnknownKey"
+	unknownSnakeKey = "zz_unknown_key"
+	unknownValue    = "must-not-reach-the-api"
+)
+
+// The protobuf snake_case spelling must decode to exactly what camelCase decodes to.
+func TestGeneratedModelsDecodeIdenticallyInBothSpellings(t *testing.T) {
+	for _, name := range sortedModelNames(t) {
+		modelType := reachableModels(t)[name]
+		t.Run(name, func(t *testing.T) {
+			camel, err := decodeGenerated(modelType, generatePayload(modelType, false, false))
+			require.NoError(t, err, "camelCase payload must decode")
+
+			snake, err := decodeGenerated(modelType, generatePayload(modelType, true, false))
+			require.NoError(t, err, "protobuf snake_case payload must decode")
+
+			require.Equal(t, camel, snake,
+				"the same document authored in protobuf snake_case decoded differently")
+		})
+	}
+}
+
+// An unknown key that survives to the request body is rejected by the API with a 400.
+func TestGeneratedModelsNeverReEmitUnknownKeys(t *testing.T) {
+	for _, name := range sortedModelNames(t) {
+		modelType := reachableModels(t)[name]
+		t.Run(name, func(t *testing.T) {
+			for _, useSnake := range []bool{false, true} {
+				target, err := decodeGeneratedInto(modelType, generatePayload(modelType, useSnake, true))
+				require.NoError(t, err, "payload with unknown keys must still decode (snake=%v)", useSnake)
+
+				encoded, err := json.Marshal(target)
+				require.NoError(t, err)
+
+				require.NotContains(t, string(encoded), unknownValue,
+					"unknown key survived Unmarshal (snake=%v)", useSnake)
+			}
+		})
+	}
+}
+
+// An enum field the walk cannot reach would decode without complaint, silently dropping
+// the value. Each is authored out-of-spec in the protobuf spelling to prove it is reached.
+func TestGeneratedEnumFieldsAreAllValidated(t *testing.T) {
+	positions := enumFieldPositions(t)
+	require.NotEmpty(t, positions, "expected to find enum fields reachable from Dashboard")
+
+	for _, position := range positions {
+		t.Run(position.model+"."+position.jsonName, func(t *testing.T) {
+			value, expectedPath := position.value()
+			encoded, err := json.Marshal(map[string]any{
+				protobufJSONFieldName(position.jsonName): value,
+			})
+			require.NoError(t, err)
+
+			target := reflect.New(position.modelType).Interface()
+			err = Unmarshal(encoded, target)
+			require.Error(t, err, "out-of-spec enum value was accepted")
+			require.Contains(t, err.Error(), expectedPath,
+				"error must name the offending field's JSON path")
+			require.Contains(t, err.Error(), position.enumName,
+				"error must name the enum type")
+		})
+	}
+}
+
+// generatePayload builds a JSON document for modelType with every field populated. Enum
+// fields are omitted since a valid value cannot be derived from the type alone;
+// TestGeneratedEnumFieldsAreAllValidated covers them.
+func generatePayload(modelType reflect.Type, useSnake, injectUnknown bool) any {
+	return generateValue(modelType, useSnake, injectUnknown)
+}
+
+func generateValue(t reflect.Type, useSnake, injectUnknown bool) any {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == reflect.TypeOf(time.Time{}) {
+		return "2026-07-28T10:00:00Z"
+	}
+
+	kind := t.Kind()
+	if kind == reflect.Struct {
+		// Nothing outside the package carries field names to normalize.
+		if t.PkgPath() != dashboardServicePackage {
+			return map[string]any{}
+		}
+		object := map[string]any{}
+		if injectUnknown {
+			object[unknownCamelKey] = unknownValue
+			object[unknownSnakeKey] = unknownValue
+		}
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			jsonName := jsonFieldName(field)
+			if enumType, _ := enumLeafType(field.Type); jsonName == "" || enumType != nil {
+				continue
+			}
+			key := jsonName
+			if useSnake {
+				key = protobufJSONFieldName(jsonName)
+			}
+			object[key] = generateValue(field.Type, useSnake, injectUnknown)
+		}
+		return object
+	}
+	if kind == reflect.Slice {
+		return []any{generateValue(t.Elem(), useSnake, injectUnknown)}
+	}
+	if kind == reflect.Map {
+		if t.Elem().Kind() == reflect.Interface {
+			// An empty-message oneOf arm, e.g. {"count": {}}. It has no fields, so any
+			// key authored inside it is an unknown one and belongs in the injection.
+			object := map[string]any{}
+			if injectUnknown {
+				object[unknownCamelKey] = unknownValue
+				object[unknownSnakeKey] = unknownValue
+			}
+			return object
+		}
+		return map[string]any{"key": generateValue(t.Elem(), useSnake, injectUnknown)}
+	}
+	if kind == reflect.Interface {
+		return map[string]any{}
+	}
+	if kind == reflect.String {
+		return "generated"
+	}
+	if kind == reflect.Bool {
+		return true
+	}
+	if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+		return 1
+	}
+	if kind == reflect.Float32 || kind == reflect.Float64 {
+		return 1.5
+	}
+	return nil
+}
+
+var oneOfGuard = regexp.MustCompile(`at most one of \[([^\]]*)\] may be set`)
+
+// A fully populated document sets every arm of every oneOf group, which the models
+// reject. Reading the group off the model's own error avoids restating the schema here.
+func decodeGeneratedInto(modelType reflect.Type, payload any) (any, error) {
+	for attempt := 0; ; attempt++ {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		target := reflect.New(modelType).Interface()
+		err = Unmarshal(encoded, target)
+		if err == nil {
+			return target, nil
+		}
+		match := oneOfGuard.FindStringSubmatch(err.Error())
+		if match == nil || attempt > 64 {
+			return nil, err
+		}
+		group := strings.Split(match[1], ",")
+		for i := range group {
+			group[i] = strings.TrimSpace(group[i])
+		}
+		if !pruneOneOfGroup(payload, group) {
+			return nil, err
+		}
+	}
+}
+
+func decodeGenerated(modelType reflect.Type, payload any) (map[string]any, error) {
+	target, err := decodeGeneratedInto(modelType, payload)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(target)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// pruneOneOfGroup keeps only the first present arm of group, in either spelling. It
+// reports whether anything was removed, so an unrepairable decode fails instead of looping.
+func pruneOneOfGroup(payload any, group []string) bool {
+	pruned := false
+	switch value := payload.(type) {
+	case map[string]any:
+		present := make([]string, 0, len(group))
+		for _, arm := range group {
+			for _, key := range []string{arm, protobufJSONFieldName(arm)} {
+				if _, ok := value[key]; ok {
+					present = append(present, key)
+					break
+				}
+			}
+		}
+		for _, key := range present[min(1, len(present)):] {
+			delete(value, key)
+			pruned = true
+		}
+		for _, nested := range value {
+			if pruneOneOfGroup(nested, group) {
+				pruned = true
+			}
+		}
+	case []any:
+		for _, item := range value {
+			if pruneOneOfGroup(item, group) {
+				pruned = true
+			}
+		}
+	}
+	return pruned
+}
+
+type enumPosition struct {
+	model     string
+	modelType reflect.Type
+	jsonName  string
+	enumName  string
+	inSlice   bool
+}
+
+// value returns the out-of-spec document and the JSON path the error must name.
+func (p enumPosition) value() (any, string) {
+	if p.inSlice {
+		return []any{"NOT_A_REAL_ENUM_VALUE"}, p.jsonName + "[0]"
+	}
+	return "NOT_A_REAL_ENUM_VALUE", p.jsonName
+}
+
+// enumFieldPositions lists every enum-typed field on every reachable model.
+func enumFieldPositions(t *testing.T) []enumPosition {
+	t.Helper()
+	var positions []enumPosition
+	for _, name := range sortedModelNames(t) {
+		modelType := reachableModels(t)[name]
+		for i := 0; i < modelType.NumField(); i++ {
+			field := modelType.Field(i)
+			jsonName := jsonFieldName(field)
+			enumType, inSlice := enumLeafType(field.Type)
+			if jsonName == "" || enumType == nil {
+				continue
+			}
+			positions = append(positions, enumPosition{
+				model:     name,
+				modelType: modelType,
+				jsonName:  jsonName,
+				enumName:  enumType.Name(),
+				inSlice:   inSlice,
+			})
+		}
+	}
+	return positions
+}
+
+// enumLeafType reports the enum a field holds, looking through pointers and slices, and
+// whether it went through a slice. Returns nil for fields holding no enum.
+func enumLeafType(t reflect.Type) (reflect.Type, bool) {
+	inSlice := false
+	for {
+		kind := t.Kind()
+		if kind == reflect.Pointer {
+			t = t.Elem()
+			continue
+		}
+		if kind == reflect.Slice {
+			inSlice = true
+			t = t.Elem()
+			continue
+		}
+		if isEnumType(t) {
+			return t, inSlice
+		}
+		return nil, false
+	}
+}
+
+var (
+	cachedModels map[string]reflect.Type
+	cachedNames  []string
+)
+
+// The model graph is acyclic, so the walks in this file need no depth limit.
+func reachableModels(t *testing.T) map[string]reflect.Type {
+	t.Helper()
+	if cachedModels == nil {
+		cachedModels = map[string]reflect.Type{}
+		collectModels(reflect.TypeOf(dashboards.Dashboard{}), cachedModels, map[reflect.Type]bool{})
+	}
+	return cachedModels
+}
+
+func sortedModelNames(t *testing.T) []string {
+	t.Helper()
+	if cachedNames == nil {
+		for name := range reachableModels(t) {
+			cachedNames = append(cachedNames, name)
+		}
+		sort.Strings(cachedNames)
+	}
+	return cachedNames
+}
+
+func collectModels(t reflect.Type, out map[string]reflect.Type, seen map[reflect.Type]bool) {
+	t = derefType(t)
+	kind := t.Kind()
+	if kind == reflect.Struct {
+		if t.PkgPath() != dashboardServicePackage || seen[t] {
+			return
+		}
+		seen[t] = true
+		out[t.Name()] = t
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if !field.IsExported() || field.Name == "AdditionalProperties" {
+				continue
+			}
+			collectModels(field.Type, out, seen)
+		}
+		return
+	}
+	if kind == reflect.Slice || kind == reflect.Map {
+		collectModels(t.Elem(), out, seen)
+	}
+}
+
+func derefType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
+}
+
+// jsonFieldName returns the field's JSON name, or "" for fields the decoder ignores.
+func jsonFieldName(field reflect.StructField) string {
+	if !field.IsExported() {
+		return ""
+	}
+	name := strings.Split(field.Tag.Get("json"), ",")[0]
+	if name == "-" {
+		return ""
+	}
+	return name
+}

--- a/go/openapi/dashboardjson/discard.go
+++ b/go/openapi/dashboardjson/discard.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboardjson
+
+import "reflect"
+
+// discardAdditionalProperties restores protojson's historical DiscardUnknown behavior.
+// The generated models collect unknown JSON keys into AdditionalProperties and re-emit
+// them on marshal, which the API rejects with a 400.
+//
+// Order matters: run this only after typed fields have been filled from snake_case
+// spellings, or it deletes every field authored in the protobuf spelling.
+func discardAdditionalProperties(value any) {
+	discardAdditionalPropertiesValue(reflect.ValueOf(value))
+}
+
+func discardAdditionalPropertiesValue(value reflect.Value) {
+	if !value.IsValid() {
+		return
+	}
+
+	kind := value.Kind()
+	if kind == reflect.Interface || kind == reflect.Pointer {
+		if !value.IsNil() {
+			discardAdditionalPropertiesValue(value.Elem())
+		}
+		return
+	}
+	if kind == reflect.Struct {
+		if value.Type().PkgPath() != dashboardServicePackage {
+			return
+		}
+		for i := 0; i < value.NumField(); i++ {
+			field := value.Field(i)
+			if value.Type().Field(i).Name == "AdditionalProperties" && field.CanSet() {
+				field.SetZero()
+				continue
+			}
+			discardAdditionalPropertiesValue(field)
+		}
+		return
+	}
+	if kind == reflect.Slice || kind == reflect.Array {
+		for i := 0; i < value.Len(); i++ {
+			discardAdditionalPropertiesValue(value.Index(i))
+		}
+		return
+	}
+	if kind == reflect.Map {
+		if value.Type().Elem().Kind() == reflect.Interface {
+			discardFreeFormObjectKeys(value)
+			return
+		}
+		for _, key := range value.MapKeys() {
+			discardAdditionalPropertiesValue(value.MapIndex(key))
+		}
+	}
+}
+
+// discardFreeFormObjectKeys empties a map[string]interface{} field. The generator emits
+// that type for a message with no fields - the marker arms of a oneOf, such as
+// {"off": {}} or {"count": {}} - so it has no AdditionalProperties to clear and every key
+// it holds is unknown. The keys are deleted in place rather than the map being replaced:
+// the map need not be settable, and a nil map is omitted by the generated MarshalJSON,
+// which would silently drop the arm from the request instead of just its unknown keys.
+func discardFreeFormObjectKeys(value reflect.Value) {
+	for _, key := range value.MapKeys() {
+		value.SetMapIndex(key, reflect.Value{})
+	}
+}

--- a/go/openapi/dashboardjson/unmarshal.go
+++ b/go/openapi/dashboardjson/unmarshal.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dashboardjson decodes opaque dashboard JSON into generated
+// dashboard_service models.
+//
+// Use this for dashboard-only documents such as Terraform content_json and
+// the operator Dashboard CR spec.json. It restores protojson-style unknown-key
+// discard before return, accepts camelCase and snake_case field names, coerces
+// bare JSON numbers for int64/uint64 string fields, and rejects unknown or
+// numeric enum values with a JSON path.
+package dashboardjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"unicode"
+
+	dashboards "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+)
+
+var dashboardServicePackage = reflect.TypeOf(dashboards.Dashboard{}).PkgPath()
+
+// Unmarshal decodes dashboard JSON into a dashboard_service model pointer.
+// It accepts camelCase and snake_case field names, coerces bare JSON numbers
+// for int64/uint64 string fields, rejects unknown/numeric enums with a JSON path,
+// and clears AdditionalProperties / free-form unknown keys before return.
+func Unmarshal(data []byte, target any) error {
+	targetType := reflect.TypeOf(target)
+	if targetType == nil || targetType.Kind() != reflect.Pointer || reflect.ValueOf(target).IsNil() {
+		return fmt.Errorf("dashboard JSON target must be a non-nil pointer")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var raw any
+	if err := decoder.Decode(&raw); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("invalid JSON after top-level value")
+		}
+		return err
+	}
+
+	normalized, err := normalizeProtoFieldNames(raw, targetType, "")
+	if err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return fmt.Errorf("marshal normalized dashboard JSON: %w", err)
+	}
+	if err := json.Unmarshal(encoded, target); err != nil {
+		return fmt.Errorf("unmarshal normalized dashboard JSON: %w", err)
+	}
+	discardAdditionalProperties(target)
+	return nil
+}
+
+// normalizeProtoFieldNames rewrites raw so that it matches what the generated models
+// expect, guided by the target type. path is the JSON path walked so far and is only
+// used to locate errors inside what is often a several-thousand-line document.
+func normalizeProtoFieldNames(raw any, targetType reflect.Type, path string) (any, error) {
+	for targetType.Kind() == reflect.Pointer {
+		targetType = targetType.Elem()
+	}
+
+	kind := targetType.Kind()
+	if kind == reflect.Struct {
+		object, ok := raw.(map[string]any)
+		// Only models are descended into, so unknown subtrees and the
+		// map[string]interface{} blobs the generator emits are left untouched.
+		if !ok || targetType.PkgPath() != dashboardServicePackage {
+			return raw, nil
+		}
+		return normalizeProtoObjectFieldNames(object, targetType, path)
+	}
+	if kind == reflect.Slice || kind == reflect.Array {
+		return normalizeProtoList(raw, targetType, path)
+	}
+	if kind == reflect.Map {
+		return normalizeProtoMap(raw, targetType, path)
+	}
+	if kind == reflect.String {
+		return normalizeProtoString(raw, targetType, path)
+	}
+	return raw, nil
+}
+
+func normalizeProtoList(raw any, targetType reflect.Type, path string) (any, error) {
+	items, ok := raw.([]any)
+	if !ok {
+		return raw, nil
+	}
+	normalized := make([]any, len(items))
+	for i, item := range items {
+		value, err := normalizeProtoFieldNames(item, targetType.Elem(), fmt.Sprintf("%s[%d]", path, i))
+		if err != nil {
+			return nil, err
+		}
+		normalized[i] = value
+	}
+	return normalized, nil
+}
+
+func normalizeProtoMap(raw any, targetType reflect.Type, path string) (any, error) {
+	object, ok := raw.(map[string]any)
+	if !ok || targetType.Key().Kind() != reflect.String {
+		return raw, nil
+	}
+	normalized := make(map[string]any, len(object))
+	for key, value := range object {
+		normalizedValue, err := normalizeProtoFieldNames(value, targetType.Elem(), childPath(path, key))
+		if err != nil {
+			return nil, err
+		}
+		normalized[key] = normalizedValue
+	}
+	return normalized, nil
+}
+
+func normalizeProtoString(raw any, targetType reflect.Type, path string) (any, error) {
+	if isEnumType(targetType) {
+		return validateEnumValue(raw, targetType, path)
+	}
+	// protobuf int64/uint64 fields (e.g. seriesCountLimit) are modeled as Go strings
+	// but commonly authored as bare JSON numbers.
+	if number, ok := raw.(json.Number); ok {
+		return number.String(), nil
+	}
+	return raw, nil
+}
+
+func normalizeProtoObjectFieldNames(object map[string]any, targetType reflect.Type, path string) (map[string]any, error) {
+	normalized := make(map[string]any, len(object))
+	consumed := make(map[string]struct{})
+
+	for i := 0; i < targetType.NumField(); i++ {
+		field := targetType.Field(i)
+		jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+		if jsonName == "" || jsonName == "-" {
+			continue
+		}
+
+		value, found := object[jsonName]
+		if found {
+			consumed[jsonName] = struct{}{}
+		}
+
+		alias := protobufJSONFieldName(jsonName)
+		if alias != jsonName {
+			if aliasValue, aliasFound := object[alias]; aliasFound {
+				// Preserve protojson's historical behavior when both spellings are
+				// present: the protobuf spelling wins.
+				value = aliasValue
+				found = true
+				consumed[alias] = struct{}{}
+			}
+		}
+
+		if found {
+			normalizedValue, err := normalizeProtoFieldNames(value, field.Type, childPath(path, jsonName))
+			if err != nil {
+				return nil, err
+			}
+			normalized[jsonName] = normalizedValue
+		}
+	}
+
+	// Unknown keys are copied through rather than dropped here, so that
+	// discardAdditionalProperties can strip them once the typed fields are in place.
+	for key, value := range object {
+		if _, ok := consumed[key]; !ok {
+			normalized[key] = value
+		}
+	}
+	return normalized, nil
+}
+
+func protobufJSONFieldName(jsonName string) string {
+	var result strings.Builder
+	for i, character := range jsonName {
+		if unicode.IsUpper(character) {
+			if i > 0 {
+				result.WriteByte('_')
+			}
+			character = unicode.ToLower(character)
+		}
+		result.WriteRune(character)
+	}
+	return result.String()
+}
+
+func childPath(parent, field string) string {
+	if parent == "" {
+		return field
+	}
+	return parent + "." + field
+}
+
+// validateEnumValue rejects the two enum spellings the generated models cannot decode.
+// The models reject them too, but their error names no path - unhelpful in a document
+// thousands of lines long. protojson discarded both silently, which renders a dashboard
+// that differs from what was authored.
+func validateEnumValue(raw any, enumType reflect.Type, path string) (any, error) {
+	switch value := raw.(type) {
+	case json.Number:
+		// Rejected before normalizeProtoString's json.Number coercion turns it into a
+		// string, which would misreport it as an unrecognized enum value.
+		return nil, fmt.Errorf("%s: numeric enum values are not supported; use the string form of %s",
+			path, enumType.Name())
+	case string:
+		if !isValidEnumValue(enumType, value) {
+			return nil, fmt.Errorf("%s: %q is not a valid %s", path, value, enumType.Name())
+		}
+		return value, nil
+	default:
+		// Nulls and structurally wrong values are left to the model's own decoding.
+		return raw, nil
+	}
+}
+
+// isEnumType reports whether t is a generated enum model: a named string type in the
+// dashboard_service package carrying an IsValid() bool method. If the generator stops
+// emitting IsValid this degrades to plain-string handling rather than failing.
+func isEnumType(t reflect.Type) bool {
+	if t.Kind() != reflect.String || t.PkgPath() != dashboardServicePackage {
+		return false
+	}
+	method, ok := t.MethodByName("IsValid")
+	return ok && method.Type.NumIn() == 1 && method.Type.NumOut() == 1 && method.Type.Out(0).Kind() == reflect.Bool
+}
+
+// isValidEnumValue asks the generated model itself, which is the only authority on the
+// accepted values: they are package-level variables, so the walk cannot read them.
+func isValidEnumValue(enumType reflect.Type, value string) bool {
+	enum := reflect.New(enumType).Elem()
+	enum.SetString(value)
+	results := enum.MethodByName("IsValid").Call(nil)
+	return len(results) == 1 && results[0].Bool()
+}

--- a/go/openapi/dashboardjson/unmarshal_test.go
+++ b/go/openapi/dashboardjson/unmarshal_test.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dashboardjson
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dashboards "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
+)
+
+// dashboardWith wraps a widget definition in the minimal envelope the model requires
+// (name and layout are declared required in the API's OpenAPI schema).
+func dashboardWith(definition string) string {
+	return fmt.Sprintf(`{
+  "name": "test dashboard",
+  "layout": {
+    "sections": [
+      {
+        "rows": [
+          {
+            "widgets": [
+              {
+                "definition": %s
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`, definition)
+}
+
+func firstWidget(t *testing.T, dashboard *dashboards.Dashboard) dashboards.Widget {
+	t.Helper()
+	require.Len(t, dashboard.Layout.Sections, 1)
+	require.Len(t, dashboard.Layout.Sections[0].Rows, 1)
+	require.Len(t, dashboard.Layout.Sections[0].Rows[0].Widgets, 1)
+	return dashboard.Layout.Sections[0].Rows[0].Widgets[0]
+}
+
+func TestUnmarshalAcceptsBothFieldNameSpellings(t *testing.T) {
+	for name, definition := range map[string]string{
+		"camelCase":  `{"dataTable": {"resultsPerPage": 20, "rowStyle": "ROW_STYLE_ONE_LINE"}}`,
+		"snake_case": `{"data_table": {"results_per_page": 20, "row_style": "ROW_STYLE_ONE_LINE"}}`,
+		"mixed":      `{"dataTable": {"results_per_page": 20, "rowStyle": "ROW_STYLE_ONE_LINE"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			dashboard := new(dashboards.Dashboard)
+			require.NoError(t, Unmarshal([]byte(dashboardWith(definition)), dashboard))
+
+			dataTable := firstWidget(t, dashboard).Definition.DataTable
+			require.NotNil(t, dataTable)
+			require.Equal(t, int32(20), *dataTable.ResultsPerPage)
+			require.Equal(t, dashboards.ROWSTYLE_ROW_STYLE_ONE_LINE, *dataTable.RowStyle)
+			require.Empty(t, dataTable.AdditionalProperties)
+		})
+	}
+}
+
+func TestUnmarshalAcceptsMixedCaseWithinOneObject(t *testing.T) {
+	json := dashboardWith(`{"lineChart": {"query_definitions": [{"id": "q1", "query": {}}]}}`)
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(json), dashboard))
+
+	lineChart := firstWidget(t, dashboard).Definition.LineChart
+	require.NotNil(t, lineChart)
+	require.Len(t, lineChart.QueryDefinitions, 1)
+	require.Equal(t, "q1", lineChart.QueryDefinitions[0].Id)
+}
+
+func TestUnmarshalPrefersProtobufSpellingWhenBothArePresent(t *testing.T) {
+	json := `{
+  "name": "test dashboard",
+  "layout": {"sections": []},
+  "relativeTimeFrame": "900s",
+  "relative_time_frame": "1800s"
+}`
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(json), dashboard))
+
+	require.Equal(t, "1800s", *dashboard.RelativeTimeFrame)
+}
+
+func TestUnmarshalDiscardsUnknownKeys(t *testing.T) {
+	json := `{
+  "name": "test dashboard",
+  "layout": {"sections": []},
+  "unknownTopLevelKey": "should be ignored",
+  "variables": [{"unknownNestedKey": true}]
+}`
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(json), dashboard))
+
+	require.Empty(t, dashboard.AdditionalProperties)
+	require.Len(t, dashboard.Variables, 1)
+	require.Empty(t, dashboard.Variables[0].AdditionalProperties)
+}
+
+func TestUnmarshalAcceptsInt64EitherAsNumberOrString(t *testing.T) {
+	for name, seriesCountLimit := range map[string]string{
+		"bare number": `20`,
+		"string":      `"20"`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			definition := fmt.Sprintf(
+				`{"lineChart": {"queryDefinitions": [{"id": "q1", "query": {}, "seriesCountLimit": %s}]}}`,
+				seriesCountLimit)
+
+			dashboard := new(dashboards.Dashboard)
+			require.NoError(t, Unmarshal([]byte(dashboardWith(definition)), dashboard))
+
+			queryDefinition := firstWidget(t, dashboard).Definition.LineChart.QueryDefinitions[0]
+			require.Equal(t, "20", *queryDefinition.SeriesCountLimit)
+		})
+	}
+}
+
+func TestUnmarshalPreservesValidEnumValues(t *testing.T) {
+	definition := `{"gauge": {"thresholdBy": "THRESHOLD_BY_VALUE", "legend": {"columns": ["LEGEND_COLUMN_NAME", "LEGEND_COLUMN_MAX"]}}}`
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(dashboardWith(definition)), dashboard))
+
+	gauge := firstWidget(t, dashboard).Definition.Gauge
+	require.Equal(t, dashboards.GAUGETHRESHOLDBY_THRESHOLD_BY_VALUE, *gauge.ThresholdBy)
+	require.Equal(t, []dashboards.LegendColumn{
+		dashboards.LEGENDCOLUMN_LEGEND_COLUMN_NAME,
+		dashboards.LEGENDCOLUMN_LEGEND_COLUMN_MAX,
+	}, gauge.Legend.Columns)
+}
+
+// An enum value the pinned SDK does not know is rejected rather than silently dropped
+// the way protojson dropped it, and the error has to say where in the document it is.
+func TestUnmarshalRejectsUnknownEnumValueNamingTheJSONPath(t *testing.T) {
+	definition := `{"gauge": {"thresholdBy": "THRESHOLD_BY_FUTURE"}}`
+
+	err := Unmarshal([]byte(dashboardWith(definition)), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "layout.sections[0].rows[0].widgets[0].definition.gauge.thresholdBy")
+	require.ErrorContains(t, err, `"THRESHOLD_BY_FUTURE" is not a valid GaugeThresholdBy`)
+}
+
+func TestUnmarshalRejectsUnknownEnumValueInRepeatedFieldWithElementIndex(t *testing.T) {
+	definition := `{"gauge": {"legend": {"columns": ["LEGEND_COLUMN_NAME", "LEGEND_COLUMN_FUTURE"]}}}`
+
+	err := Unmarshal([]byte(dashboardWith(definition)), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "definition.gauge.legend.columns[1]")
+	require.ErrorContains(t, err, `"LEGEND_COLUMN_FUTURE" is not a valid LegendColumn`)
+}
+
+// Numeric enums must be reported distinctly: the int64 coercion would otherwise turn 1
+// into "1" and report it as an unrecognized enum value, which is misleading.
+func TestUnmarshalRejectsNumericEnumWithADistinctMessage(t *testing.T) {
+	definition := `{"gauge": {"thresholdBy": 1}}`
+
+	err := Unmarshal([]byte(dashboardWith(definition)), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "definition.gauge.thresholdBy")
+	require.ErrorContains(t, err, "numeric enum values are not supported; use the string form of GaugeThresholdBy")
+}
+
+func TestUnmarshalRejectsTrailingContentAfterTopLevelValue(t *testing.T) {
+	err := Unmarshal([]byte(`{"name": "a", "layout": {}} {"name": "b"}`), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "invalid JSON after top-level value")
+}
+
+func TestUnmarshalRejectsMissingRequiredProperties(t *testing.T) {
+	err := Unmarshal([]byte(`{"layout": {"sections": []}}`), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "no value given for required property name")
+}
+
+func TestUnmarshalRejectsTwoOneOfArmsSet(t *testing.T) {
+	definition := `{"dataTable": {"query": {"logs": {}, "spans": {}}}}`
+
+	err := Unmarshal([]byte(dashboardWith(definition)), new(dashboards.Dashboard))
+
+	require.ErrorContains(t, err, "may be set")
+}
+
+func TestUnmarshalRejectsNonPointerTarget(t *testing.T) {
+	require.ErrorContains(t, Unmarshal([]byte(`{}`), dashboards.Dashboard{}), "non-nil pointer")
+	require.ErrorContains(t, Unmarshal([]byte(`{}`), (*dashboards.Dashboard)(nil)), "non-nil pointer")
+}
+
+// Unmarshal promotes protobuf spellings into typed fields, then strips unknown keys
+// the API would reject.
+func TestUnmarshalPromotesSnakeCaseThenDiscardsUnknownKeys(t *testing.T) {
+	json := `{
+  "name": "test dashboard",
+  "unknownTopLevelKey": "should be ignored",
+  "layout": {
+    "sections": [
+      {
+        "rows": [
+          {
+            "widgets": [
+              {
+                "definition": {
+                  "data_table": {
+                    "results_per_page": 20,
+                    "unknownNestedKey": "should be ignored"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(json), dashboard))
+
+	require.Empty(t, dashboard.AdditionalProperties)
+	dataTable := firstWidget(t, dashboard).Definition.DataTable
+	require.NotNil(t, dataTable)
+	require.Equal(t, int32(20), *dataTable.ResultsPerPage)
+	require.Empty(t, dataTable.AdditionalProperties)
+}
+
+// A message with no fields is modeled as a free-form map, not a struct, so unknown keys
+// authored inside one have no AdditionalProperties to land in and have to be deleted from
+// the map itself. The emptied arm still has to be sent - it is what selects the oneOf case.
+func TestUnmarshalEmptiesUnknownKeysInFieldlessMessages(t *testing.T) {
+	json := `{
+  "name": "test dashboard",
+  "layout": {"sections": []},
+  "off": {"unknownKey": "should be ignored"},
+  "variables": [
+    {
+      "name": "v",
+      "definition": {"multiSelect": {"selection": {"all": {"unknownNestedKey": "should be ignored"}}}}
+    }
+  ]
+}`
+
+	dashboard := new(dashboards.Dashboard)
+	require.NoError(t, Unmarshal([]byte(json), dashboard))
+
+	require.NotNil(t, dashboard.Off)
+	require.Empty(t, dashboard.Off)
+	require.Len(t, dashboard.Variables, 1)
+	allSelection := dashboard.Variables[0].Definition.MultiSelect.Selection.All
+	require.NotNil(t, allSelection)
+	require.Empty(t, allSelection)
+
+	// The generated marshaler omits a nil map, so emptying the arm must not nil it out:
+	// that would drop the whole arm from the request rather than just its unknown keys.
+	serialized, err := dashboard.ToMap()
+	require.NoError(t, err)
+	require.Equal(t, map[string]interface{}{}, serialized["off"])
+}


### PR DESCRIPTION
## Summary
- Add `go/openapi/dashboardjson` with `Unmarshal` for dashboard JSON (Terraform `content_json`, operator `spec.json`).
- Accepts camelCase and snake_case. Converts bare JSON numbers to strings for int64/uint64 fields. Rejects unknown or numeric enums and reports the JSON path. Removes unknown keys before return.

## Operator usage

After the operator bumps the SDK, replace the local helper with:

```go
import (
    dashboards "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/dashboard_service"
    "github.com/coralogix/coralogix-management-sdk/go/openapi/dashboardjson"
)

dashboard := new(dashboards.Dashboard)
if err := dashboardjson.Unmarshal([]byte(contentJson), dashboard); err != nil {
    return nil, fmt.Errorf("failed to unmarshal contentJson: %w", err)
}
```

No separate discard step. `Unmarshal` already removes unknown keys.

Example input (snake_case and camelCase both work; snake wins if both are present):

```json
{
  "name": "errors",
  "layout": {
    "sections": [{
      "rows": [{
        "widgets": [{
          "definition": {
            "data_table": {
              "results_per_page": 20,
              "row_style": "ROW_STYLE_ONE_LINE"
            }
          }
        }]
      }]
    }]
  },
  "unknownTopLevelKey": "stripped-before-api"
}
```

`unknownTopLevelKey` is removed, so it is not sent to the API.

Until this SDK change is released, keep the operator’s local `internal/utils/dashboardjson`. Then bump the SDK, switch the import, and delete the local package.

## Test plan
- [x] `go test ./go/openapi/dashboardjson/...`
- [ ] Operator follow-up: switch to this package after SDK release