### PR TITLE
fix: serve REST (SCIM) endpoints from api.<domain> instead of ng-api-http

### DIFF
--- a/go/cxsdk.go
+++ b/go/cxsdk.go
@@ -37,16 +37,17 @@ const (
 	GrpcAP3 = "ng-api-grpc.ap3.coralogix.com:443"
 )
 
-// RESt URLs for the Coralogix regions.
+// REST URLs for the Coralogix regions. These are served from the same api.<domain>
+// host as the OpenAPI endpoints, so a tenant only needs that one host resolvable.
 const (
-	RestUS1 = "https://ng-api-http.coralogix.us"
-	RestUS2 = "https://ng-api-http.cx498.coralogix.com"
-	RestUS3 = "https://ng-api-http.us3.coralogix.com"
-	RestEU1 = "https://ng-api-http.coralogix.com"
-	RestEU2 = "https://ng-api-http.eu2.coralogix.com"
-	RestAP1 = "https://ng-api-http.app.coralogix.in"
-	RestAP2 = "https://ng-api-http.coralogixsg.com"
-	RestAP3 = "https://ng-api-http.ap3.coralogix.com"
+	RestUS1 = "https://api.coralogix.us"
+	RestUS2 = "https://api.cx498.coralogix.com"
+	RestUS3 = "https://api.us3.coralogix.com"
+	RestEU1 = "https://api.coralogix.com"
+	RestEU2 = "https://api.eu2.coralogix.com"
+	RestAP1 = "https://api.app.coralogix.in"
+	RestAP2 = "https://api.coralogixsg.com"
+	RestAP3 = "https://api.ap3.coralogix.com"
 )
 
 // SdkAPIError is an error that occurs in the Coralogix SDK.
@@ -375,12 +376,11 @@ func CoralogixGrpcEndpointFromRegion(regionIdentifier string) string {
 }
 
 // normalizeCoralogixDomain reduces a Coralogix domain to its base form by
-// stripping a leading "api." label. The OpenAPI/REST client identifies a
-// tenant by its API host (e.g. "api.eu2.coralogix.com"), whereas the gRPC and
-// ng-api REST endpoints are derived by prefixing the base domain
-// (e.g. "eu2.coralogix.com") with "ng-api-grpc." / "ng-api-http.". Normalizing
-// here lets callers pass either form interchangeably and still reach the
-// correct host for every protocol.
+// stripping a leading "api." label. Callers identify a tenant by its API host
+// (e.g. "api.eu2.coralogix.com"), while endpoints are derived by prefixing the
+// base domain (e.g. "eu2.coralogix.com") with "api." for REST and
+// "ng-api-grpc." for gRPC. Normalizing here lets callers pass either form
+// interchangeably and still reach the correct host for every protocol.
 func normalizeCoralogixDomain(domain string) string {
 	return strings.TrimPrefix(domain, "api.")
 }
@@ -417,12 +417,12 @@ func CoralogixRestEndpointFromRegion(regionIdentifier string) string {
 	}
 }
 
-// CoralogixRestEndpointFromDomain returns the ng-api REST endpoint for a custom
+// CoralogixRestEndpointFromDomain returns the REST endpoint for a custom
 // Coralogix domain (e.g. "eu2.coralogix.com" or "mycompany.coralogix.com").
 // A leading "api." is tolerated so the same domain value used to configure the
 // OpenAPI client also yields the correct REST host.
 func CoralogixRestEndpointFromDomain(domain string) string {
-	return fmt.Sprintf("https://ng-api-http.%s", normalizeCoralogixDomain(domain))
+	return fmt.Sprintf("https://api.%s", normalizeCoralogixDomain(domain))
 }
 
 // AuthContext is a struct that holds the API keys for the Coralogix SDK.

--- a/go/endpoint_resolution_test.go
+++ b/go/endpoint_resolution_test.go
@@ -50,8 +50,8 @@ func TestCoralogixGrpcEndpointFromDomain(t *testing.T) {
 func TestCoralogixRestEndpointFromRegion(t *testing.T) {
 	cases := map[string]string{
 		"eu2":                    RestEU2,
-		"acme.coralogix.com":     "https://ng-api-http.acme.coralogix.com",
-		"api.acme.coralogix.com": "https://ng-api-http.acme.coralogix.com",
+		"acme.coralogix.com":     "https://api.acme.coralogix.com",
+		"api.acme.coralogix.com": "https://api.acme.coralogix.com",
 	}
 	for in, want := range cases {
 		if got := CoralogixRestEndpointFromRegion(in); got != want {
@@ -62,8 +62,8 @@ func TestCoralogixRestEndpointFromRegion(t *testing.T) {
 
 func TestCoralogixRestEndpointFromDomain(t *testing.T) {
 	cases := map[string]string{
-		"acme.coralogix.com":     "https://ng-api-http.acme.coralogix.com",
-		"api.acme.coralogix.com": "https://ng-api-http.acme.coralogix.com",
+		"acme.coralogix.com":     "https://api.acme.coralogix.com",
+		"api.acme.coralogix.com": "https://api.acme.coralogix.com",
 	}
 	for in, want := range cases {
 		if got := CoralogixRestEndpointFromDomain(in); got != want {


### PR DESCRIPTION
## Why

A BYOC + FedRAMP tenant behind PrivateLink only has `api.<domain>` published — additional records like `ng-api-grpc.<domain>` and `ng-api-http.<domain>` can't be created. Anything the SDK derives from those hostnames is unreachable there.

In this SDK, `CoralogixRestEndpointFromRegion` / `FromDomain` (and the `Rest*` constants) have exactly **one** consumer: the SCIM users client (`go/users-client.go:152`). So `ng-api-http` is the single reason a consumer needs a second hostname resolvable.

It turns out `api.<domain>` serves the same `/scim` tree, so the extra hostname buys nothing.

## What

Repoint the REST endpoint constants and the domain helper at `api.*`:

```
RestUS1  ng-api-http.coralogix.us        -> api.coralogix.us
RestUS2  ng-api-http.cx498.coralogix.com -> api.cx498.coralogix.com
RestUS3  ng-api-http.us3.coralogix.com   -> api.us3.coralogix.com
RestEU1  ng-api-http.coralogix.com       -> api.coralogix.com
RestEU2  ng-api-http.eu2.coralogix.com   -> api.eu2.coralogix.com
RestAP1  ng-api-http.app.coralogix.in    -> api.app.coralogix.in
RestAP2  ng-api-http.coralogixsg.com     -> api.coralogixsg.com
RestAP3  ng-api-http.ap3.coralogix.com   -> api.ap3.coralogix.com

CoralogixRestEndpointFromDomain(d) -> "https://api." + d   (was ng-api-http.)
```

Plus the doc comments that described the old derivation, and the two endpoint-resolution test cases.

## Verification

`GET /scim/Users` was run against the old and the new host in **every region, using that region's own team key**. All 16 calls returned 200, and each region's two responses are **byte-identical**:

| region | old `ng-api-http` host | new `api` host | result |
|---|---|---|---|
| EU1 | ng-api-http.coralogix.com | api.coralogix.com | 200 / 200 — identical (98 B, 0 users) |
| EU2 | ng-api-http.eu2.coralogix.com | api.eu2.coralogix.com | 200 / 200 — identical (2538 users) |
| US1 | ng-api-http.coralogix.us | api.coralogix.us | 200 / 200 — identical (507 B, 1 user) |
| US2 | ng-api-http.cx498.coralogix.com | api.cx498.coralogix.com | 200 / 200 — identical (514 B, 1 user) |
| US3 | ng-api-http.us3.coralogix.com | api.us3.coralogix.com | 200 / 200 — identical (543 B, 1 user) |
| AP1 | ng-api-http.app.coralogix.in | api.app.coralogix.in | 200 / 200 — identical (536 B, 1 user) |
| AP2 | ng-api-http.coralogixsg.com | api.coralogixsg.com | 200 / 200 — identical (98 B, 0 users) |
| AP3 | ng-api-http.ap3.coralogix.com | api.ap3.coralogix.com | 200 / 200 — identical (98 B, 0 users) |

Two honest caveats:

- The EU1, AP2 and AP3 tenants I tested have **no SCIM users**, so there both hosts return an identical empty `ListResponse`. That proves routing and auth work, but doesn't compare payloads. The five regions with data (EU2, US1, US2, US3, AP1) do compare byte-for-byte.
- `api.cx498.coralogix.com` (US2) was specifically questioned. It resolves and serves SCIM: 200, one user, identical to `ng-api-http.cx498.coralogix.com`.

Also worth noting: the OpenAPI-style names (`api.eu1.coralogix.com`, `api.us1.coralogix.com`, `api.us2.coralogix.com`, `api.ap1.coralogix.com`, `api.ap2.coralogix.com`) serve SCIM as well — both naming families work. I used the straight prefix swap so the region constants keep the same base domain as before, which also matches how `CoralogixRestEndpointFromDomain` derives custom/BYOC domains.

`/scim/Groups` answers on `api.*` too (relevant to the Terraform provider, which has its own SCIM groups client).

`go build ./...`, `go vet ./...` and the root-package tests pass.

## Compatibility

These are exported symbols, so this changes the host that any external consumer of them talks to. Two mitigations:

- Within this repo, the only consumer is the SCIM users client.
- The Terraform provider does **not** import them — it carries its own copy (`internal/clientset/endpoints.go`, whose comment explicitly mirrors `CoralogixRestEndpointFromRegion`). It has the same FedRAMP limitation and would need the same change separately.

Worth calling out in the release notes regardless, since the behavior of a public API changes.

## Not included

`rust/cx-sdk/src/lib.rs` carries the identical `ng-api-http` mapping and is untouched — happy to do it as a follow-up, but I kept this PR to Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
