### PR TITLE
chore: bump Go to 1.26 in both modules

### DIFF
--- a/.github/workflows/test-tf-import.yml
+++ b/.github/workflows/test-tf-import.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test-tf-import.yml
+++ b/.github/workflows/test-tf-import.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 8 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test-tf-import:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coralogix/coralogix-management-sdk
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/tools/terraform-importer/go.mod
+++ b/tools/terraform-importer/go.mod
@@ -1,6 +1,6 @@
 module github.com/coralogix/coralogix-management-sdk/tools/terraform-importer
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
Bumps the `go` directive to `1.26.0` in both modules, plus the one hardcoded Go version in `test-tf-import.yml`. Other CI jobs pick it up via `go-version-file` / `GOTOOLCHAIN=auto`.

#665 landed on 1.25 only because `grpc v1.82.1` required it. 1.26 has been out since early 2026, and 1.25 loses security support once 1.27 ships.

No linter change needed: the pinned `golangci-lint v2.12.2` is built with go1.26.2. Locally on 1.26.3: build, vet, forward-compat tests, and lint (0 issues) all pass; `go mod tidy` is a no-op.

Also closes code-scanning alert [#14](https://github.com/coralogix/coralogix-management-sdk/security/code-scanning/14): `test-tf-import.yml` had no `permissions` block, so it inherited the repo's default `GITHUB_TOKEN` scope. Added `contents: read` — the job only checks out code, runs a test script, and uploads a log artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)